### PR TITLE
chore: move up skills and achievements

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -174,14 +174,14 @@ const Home: React.FC = () => {
             <Grid item xs={12} lg={8}>
               <Summary />
               <Links links={links} />
+              <Skills skills={skills} />
+              <Achievements achievements={achievements} />
               {experiences.map((exp, key) => (
                 <Experience {...exp} key={key} />
               ))}
               {educations.map((edu, key) => (
                 <Education {...edu} key={key} />
               ))}
-              <Skills skills={skills} />
-              <Achievements achievements={achievements} />
             </Grid>
           </Grid>
         </Box>


### PR DESCRIPTION
This PR reorganizes the homepage layout to improve information hierarchy:

- Moved Skills and Achievements sections above work experience
- Places qualifications before chronological details
- Improves scan-ability for recruiters reviewing credentials

The change prioritizes capability showcase before diving into employment history.