### PR TITLE
chore: add skills component unit tests

### DIFF
--- a/src/components/Skills.test.tsx
+++ b/src/components/Skills.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import Skills from './Skills'
+
+describe('Skills', () => {
+  const mockSkills = [
+    { label: 'React', url: 'https://example.com/react' },
+    { label: 'TypeScript', url: 'https://example.com/typescript' },
+    { label: 'Material UI', url: 'https://example.com/mui' },
+  ]
+
+  it('renders the skills heading', () => {
+    render(<Skills skills={mockSkills} />)
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+  })
+
+  it('renders all skill chips with correct labels', () => {
+    render(<Skills skills={mockSkills} />)
+
+    mockSkills.forEach((skill) => {
+      const chip = screen.getByText(skill.label)
+      expect(chip).toBeInTheDocument()
+    })
+  })
+
+  it('creates chips with correct links and accessibility attributes', () => {
+    render(<Skills skills={mockSkills} />)
+
+    mockSkills.forEach((skill) => {
+      const link = screen.getByText(skill.label).closest('a')
+      expect(link).toHaveAttribute('href', skill.url)
+      expect(link).toHaveAttribute('aria-label', `Read more about ${skill.label}`)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds deterministic tests for the Skills component with a focus on maintainability.

### Test Coverage

- Heading rendering verification
- Content display of all skill chips
- Proper link functionality and accessibility