### PR TITLE
chore: replace hardcoded colors with theme variables

### DIFF
--- a/src/components/LazySyntaxHighlighter.tsx
+++ b/src/components/LazySyntaxHighlighter.tsx
@@ -13,7 +13,7 @@ const LazySyntaxHighlighter: React.FC<LazySyntaxHighlighterProps> = (props) => {
   return (
     <Suspense
       fallback={
-        <Box sx={{ p: 2, bgcolor: '#2d2d2d', borderRadius: 1, my: 2 }}>
+        <Box sx={{ p: 2, bgcolor: 'background.paper', borderRadius: 1, my: 2 }}>
           <CircularProgress size={20} color='inherit' />
         </Box>
       }

--- a/src/components/LoadingFallback.tsx
+++ b/src/components/LoadingFallback.tsx
@@ -9,7 +9,7 @@ const LoadingFallback: React.FC = () => (
       alignItems: 'center',
       minHeight: '100vh',
       width: '100vw',
-      bgcolor: '#121212',
+      bgcolor: 'background.default',
       margin: 0,
       padding: 0,
       position: 'fixed',


### PR DESCRIPTION
This PR removes hardcoded colors in favor of Material UI theme tokens.

### Changes

- LazySyntaxHighlighter: #2d2d2d → background.paper
- LoadingFallback: #121212 → background.default

### Benefits

- Improves maintainability
- Prepares for theme system