### PR TITLE
feat: add theme toggle

### DIFF
--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,21 +1,30 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import Header from './Header'
+import { ThemeProvider } from '../contexts/ThemeContext'
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>)
+}
 
 describe('Header', () => {
-  it('renders the header with title and navigation buttons', () => {
-    render(<Header />)
+  it('renders the header with title, theme toggle, and navigation buttons', () => {
+    renderWithTheme(<Header />)
 
     // Check for title
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
 
-    // Check for navigation buttons (3 total)
+    // Check for theme toggle button (1 button)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(1)
+
+    // Check for navigation links (3 total)
     const navButtons = screen.getAllByRole('link')
     expect(navButtons).toHaveLength(3)
   })
 
   it('renders social media and resume links with correct attributes', () => {
-    render(<Header />)
+    renderWithTheme(<Header />)
 
     // Get all links
     const links = screen.getAllByRole('link')
@@ -39,11 +48,23 @@ describe('Header', () => {
   })
 
   it('provides accessible label for the resume button', () => {
-    render(<Header />)
+    renderWithTheme(<Header />)
 
     // Check that the resume button has an accessible label
     const resumeButton = screen.getByLabelText('Resume')
     expect(resumeButton).toBeInTheDocument()
     expect(resumeButton).toHaveAccessibleName('Resume')
+  })
+
+  it('renders theme toggle with proper accessibility', () => {
+    renderWithTheme(<Header />)
+
+    // Check that theme toggle button exists
+    const themeToggle = screen.getByRole('button')
+    expect(themeToggle).toBeInTheDocument()
+
+    // Check that it has proper aria-label
+    expect(themeToggle).toHaveAttribute('aria-label')
+    expect(themeToggle.getAttribute('aria-label')).toContain('Current theme:')
   })
 })

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { AppBar, Toolbar, Typography, IconButton } from '@mui/material'
 import LinkedInIcon from '@mui/icons-material/LinkedIn'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import DescriptionIcon from '@mui/icons-material/Description'
+import ThemeToggle from './ThemeToggle'
 
 function Header() {
   return (
@@ -10,6 +11,7 @@ function Header() {
         <Typography component='h1' variant='h6' style={{ flexGrow: 1 }}>
           Raymond Perez
         </Typography>
+        <ThemeToggle />
         <IconButton
           href='https://www.linkedin.com/in/raymond-perez-eng/'
           color='inherit'

--- a/src/components/SyntaxHighlighterWithTheme.tsx
+++ b/src/components/SyntaxHighlighterWithTheme.tsx
@@ -12,8 +12,8 @@ const SyntaxHighlighterWithTheme: React.FC<SyntaxHighlighterWithThemeProps> = ({
   language,
   children,
 }) => {
-  const { computedTheme } = useTheme()
-  const syntaxTheme = computedTheme === 'light' ? materialLight : materialDark
+  const { themeMode } = useTheme()
+  const syntaxTheme = themeMode === 'light' ? materialLight : materialDark
 
   return (
     <SyntaxHighlighter language={language} style={syntaxTheme}>

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Theme } from '@mui/material'
+import ThemeToggle from './ThemeToggle'
+import { ThemeProvider } from '../contexts/ThemeContext'
+import { useTheme } from '../contexts/useTheme'
+
+// Mock the useTheme hook
+vi.mock('../contexts/useTheme')
+
+const mockUseTheme = vi.mocked(useTheme)
+
+describe('ThemeToggle', () => {
+  const mockSetThemeMode = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSetThemeMode.mockClear()
+  })
+
+  const renderWithTheme = (themeMode: 'light' | 'dark' = 'dark') => {
+    mockUseTheme.mockReturnValue({
+      themeMode,
+      theme: {} as Theme,
+      setThemeMode: mockSetThemeMode,
+    })
+
+    return render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    )
+  }
+
+  describe('Icon Display', () => {
+    it('displays dark mode icon when theme is dark', () => {
+      renderWithTheme('dark')
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-label', 'Current theme: dark. Switch to light theme')
+
+      const icon = screen.getByTestId('DarkModeIcon')
+      expect(icon).toBeInTheDocument()
+    })
+
+    it('displays light mode icon when theme is light', () => {
+      renderWithTheme('light')
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-label', 'Current theme: light. Switch to dark theme')
+
+      const icon = screen.getByTestId('LightModeIcon')
+      expect(icon).toBeInTheDocument()
+    })
+  })
+
+  describe('Theme Switching', () => {
+    it('switches from light to dark when clicked', () => {
+      renderWithTheme('light')
+
+      const button = screen.getByRole('button')
+      fireEvent.click(button)
+
+      expect(mockSetThemeMode).toHaveBeenCalledWith('dark')
+    })
+
+    it('switches from dark to light when clicked', () => {
+      renderWithTheme('dark')
+
+      const button = screen.getByRole('button')
+      fireEvent.click(button)
+
+      expect(mockSetThemeMode).toHaveBeenCalledWith('light')
+    })
+  })
+
+  describe('Tooltips', () => {
+    it('shows correct tooltip for dark theme', () => {
+      renderWithTheme('dark')
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAccessibleName('Current theme: dark. Switch to light theme')
+    })
+
+    it('shows correct tooltip for light theme', () => {
+      renderWithTheme('light')
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAccessibleName('Current theme: light. Switch to dark theme')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has proper button role', () => {
+      renderWithTheme('dark')
+
+      const button = screen.getByRole('button')
+      expect(button).toBeInTheDocument()
+    })
+
+    it('has descriptive aria-label', () => {
+      renderWithTheme('dark')
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-label')
+      expect(button.getAttribute('aria-label')).toContain('Current theme:')
+    })
+  })
+})

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import { IconButton, Tooltip } from '@mui/material'
+import LightModeIcon from '@mui/icons-material/LightMode'
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import { useTheme } from '../contexts/useTheme'
+
+const ThemeToggle: React.FC = () => {
+  const { themeMode, setThemeMode } = useTheme()
+
+  const handleToggle = () => {
+    const nextMode = themeMode === 'light' ? 'dark' : 'light'
+    setThemeMode(nextMode)
+  }
+
+  const getIcon = () => {
+    return themeMode === 'light' ? <LightModeIcon /> : <DarkModeIcon />
+  }
+
+  const getTooltip = () => {
+    return themeMode === 'light' ? 'Switch to dark theme' : 'Switch to light theme'
+  }
+
+  return (
+    <Tooltip title={getTooltip()}>
+      <IconButton
+        onClick={handleToggle}
+        color='inherit'
+        aria-label={`Current theme: ${themeMode}. ${getTooltip()}`}
+      >
+        {getIcon()}
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+export default ThemeToggle

--- a/src/contexts/ThemeTypes.ts
+++ b/src/contexts/ThemeTypes.ts
@@ -1,9 +1,7 @@
-export type ThemeMode = 'light' | 'dark' | 'system'
-export type ComputedTheme = 'light' | 'dark'
+export type ThemeMode = 'light' | 'dark'
 
 export interface ThemeContextType {
   themeMode: ThemeMode
-  computedTheme: ComputedTheme
   theme: import('@mui/material').Theme
   setThemeMode: (mode: ThemeMode) => void
 }


### PR DESCRIPTION
This PR adds a theme toggle button and simplifies the theme system.
### Changes

- Removed 'system' theme option, now only light/dark
- Added theme toggle button in header
- Updated theme context and related components