### PR TITLE
feat: add article reading time

### DIFF
--- a/src/components/BlogPost.test.tsx
+++ b/src/components/BlogPost.test.tsx
@@ -110,4 +110,23 @@ describe('BlogPost', () => {
     })
     expect(metaTag).toBeInTheDocument()
   })
+
+  it('displays reading time for article content', () => {
+    const contentWithWords = (
+      <div data-testid='blog-content'>
+        <p>This is a test article with some content.</p>
+        <p>It has multiple paragraphs to test the reading time calculation.</p>
+        <p>The reading time should be calculated based on the total word count.</p>
+      </div>
+    )
+
+    render(
+      <BrowserRouter>
+        <BlogPost {...defaultProps} children={contentWithWords} />
+      </BrowserRouter>,
+    )
+
+    // Check that reading time is displayed
+    expect(screen.getByText(/min read/)).toBeInTheDocument()
+  })
 })

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -26,6 +26,7 @@ import profileImage from '../assets/raymond-perez.jpg'
 import withCanonical from './WithCanonical.tsx'
 import { PROFILE } from '../constants/profile'
 import { useBookmarks } from '../hooks/useBookmarks'
+import { calculateReadingTime, formatReadingTime } from '../utils/readingTime'
 
 interface BlogPostProps {
   title: string
@@ -45,6 +46,23 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
 
   const currentPath = location.pathname
   const isCurrentlyBookmarked = isBookmarked(currentPath)
+
+  // Calculate reading time from children content
+  const extractTextFromChildren = (children: React.ReactNode): string => {
+    let text = ''
+    React.Children.forEach(children, (child) => {
+      if (typeof child === 'string') {
+        text += child
+      } else if (React.isValidElement(child)) {
+        text += extractTextFromChildren(child.props.children)
+      }
+    })
+    return text
+  }
+
+  const textContent = extractTextFromChildren(children)
+  const readingTime = calculateReadingTime(textContent)
+  const readingTimeDisplay = formatReadingTime(readingTime)
 
   useEffect(() => {
     const handleScroll = (): void => {
@@ -120,6 +138,11 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
                     {isCurrentlyBookmarked ? <BookmarkIcon /> : <BookmarkBorderIcon />}
                   </IconButton>
                 </Tooltip>
+              </Box>
+              <Box mb={2}>
+                <Typography variant='body2' color='text.secondary'>
+                  {readingTimeDisplay}
+                </Typography>
               </Box>
               {children}
             </Grid>

--- a/src/utils/readingTime.test.ts
+++ b/src/utils/readingTime.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { calculateReadingTime, formatReadingTime } from './readingTime'
+
+describe('readingTime', () => {
+  describe('calculateReadingTime', () => {
+    it('should calculate reading time for short text', () => {
+      const text = 'This is a short text with ten words exactly here.'
+      const result = calculateReadingTime(text)
+      expect(result).toBe(1) // Should round up to at least 1 minute
+    })
+
+    it('should calculate reading time for longer text', () => {
+      // Create text with approximately 400 words (should be 2 minutes at 200 wpm)
+      const text = 'word '.repeat(400)
+      const result = calculateReadingTime(text)
+      expect(result).toBe(2)
+    })
+
+    it('should handle empty text', () => {
+      const result = calculateReadingTime('')
+      expect(result).toBe(1) // Should return at least 1 minute
+    })
+
+    it('should handle text with extra whitespace', () => {
+      const text = '  This   is   text   with   extra   whitespace  '
+      const result = calculateReadingTime(text)
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('formatReadingTime', () => {
+    it('should format reading time correctly', () => {
+      expect(formatReadingTime(1)).toBe('1 min read')
+      expect(formatReadingTime(5)).toBe('5 min read')
+      expect(formatReadingTime(10)).toBe('10 min read')
+    })
+  })
+})

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -1,0 +1,14 @@
+const WORDS_PER_MINUTE = 200
+
+export const calculateReadingTime = (text: string): number => {
+  const trimmedText = text.trim()
+  if (!trimmedText) return 1
+
+  const words = trimmedText.split(/\s+/).length
+  const minutes = Math.ceil(words / WORDS_PER_MINUTE)
+  return Math.max(minutes, 1)
+}
+
+export const formatReadingTime = (minutes: number): string => {
+  return `${minutes} min read`
+}


### PR DESCRIPTION
This PR adds estimated reading time display to all blog articles.
### Changes Made

- Created readingTime.ts utility with word count calculation (200 WPM standard)
- Enhanced BlogPost component to extract text and display reading time
- Added comprehensive tests for new functionality

### Implementation

- Reading time appears below article title as secondary text
- Automatically calculates from article content
- Minimum 1-minute display for short articles