### PR TITLE
feat: add seo experience schema

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,5 +1,8 @@
 import { Box, Card, CardContent, Typography } from '@mui/material'
 import React from 'react'
+import { helmetJsonLdProp } from 'react-schemaorg'
+import { Occupation } from 'schema-dts'
+import { Helmet } from 'react-helmet'
 
 type Experience = {
   title: string
@@ -9,20 +12,32 @@ type Experience = {
 }
 
 const Experience: React.FC<Experience> = ({ title, company, duration, bullets }) => (
-  <Card style={{ marginTop: 16 }}>
-    <CardContent>
-      <Typography variant='h5' gutterBottom>
-        {title}
-      </Typography>
-      <Typography variant='subtitle1' color='textSecondary'>
-        {company} - {duration}
-      </Typography>
-      {bullets.map((bullet, key) => (
-        <Box marginTop={2} key={key}>
-          <Typography variant='body1'>{bullet}</Typography>
-        </Box>
-      ))}
-    </CardContent>
-  </Card>
+  <React.Fragment>
+    <Helmet
+      script={[
+        helmetJsonLdProp<Occupation>({
+          '@context': 'https://schema.org',
+          '@type': 'Occupation',
+          name: title,
+          responsibilities: bullets.join(' '),
+        }),
+      ]}
+    />
+    <Card style={{ marginTop: 16 }}>
+      <CardContent>
+        <Typography variant='h5' gutterBottom>
+          {title}
+        </Typography>
+        <Typography variant='subtitle1' color='textSecondary'>
+          {company} - {duration}
+        </Typography>
+        {bullets.map((bullet, key) => (
+          <Box marginTop={2} key={key}>
+            <Typography variant='body1'>{bullet}</Typography>
+          </Box>
+        ))}
+      </CardContent>
+    </Card>
+  </React.Fragment>
 )
 export default Experience


### PR DESCRIPTION
This PR adds Schema.org structured data to Experience components.

## Changes
- Added Occupation schema with job title and responsibilities  
- Uses same pattern as BlogPost/Home components

## Benefits
- Better SEO
- Potential rich snippets