### PR TITLE
feat: add more person schema

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -151,6 +151,25 @@ const Home: React.FC = () => {
               name: 'Red Rocks Community College',
             },
             image: profileImage,
+            url: 'https://www.rayperez.com',
+            knowsAbout: [
+              'Software Engineering',
+              'Web Development',
+              'React.js',
+              'Node.js',
+              'TypeScript',
+              'Laravel',
+              'GraphQL',
+              'NestJS',
+              'Object-Oriented Programming',
+            ],
+            hasOccupation: [
+              {
+                '@type': 'Occupation',
+                name: 'Senior Software Engineer',
+                occupationalCategory: 'Software Development',
+              },
+            ],
             sameAs: [
               'https://prejump.com',
               'https://twitch.tv/onlyray',


### PR DESCRIPTION
This PR enhances schema.org Person metadata in Home.tsx.
### Changes

- Added url property with canonical site URL
- Added knowsAbout array with technical skills
- Added hasOccupation with structured occupation data

### Benefits

- Improved SEO metadata
- Better search engine understanding