### PR TITLE
feat: add image lazy loading to profile card

### DIFF
--- a/src/components/LazyImage.test.tsx
+++ b/src/components/LazyImage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import LazyImage from './LazyImage'
+
+describe('LazyImage', () => {
+  const defaultProps = {
+    src: '/test-image.jpg',
+    alt: 'Test image',
+    width: 200,
+    height: 200,
+  }
+
+  it('renders with loading state initially', () => {
+    render(<LazyImage {...defaultProps} />)
+
+    expect(screen.getByRole('img')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('removes loading state after image loads', () => {
+    render(<LazyImage {...defaultProps} />)
+
+    const img = screen.getByRole('img')
+    fireEvent.load(img)
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+
+  it('uses eager loading for priority images', () => {
+    render(<LazyImage {...defaultProps} priority />)
+
+    expect(screen.getByRole('img')).toHaveAttribute('loading', 'eager')
+  })
+
+  it('uses lazy loading by default', () => {
+    render(<LazyImage {...defaultProps} />)
+
+    expect(screen.getByRole('img')).toHaveAttribute('loading', 'lazy')
+  })
+
+  it('passes through additional props to img element', () => {
+    render(<LazyImage {...defaultProps} className='test-class' data-testid='test-id' />)
+
+    const img = screen.getByRole('img')
+    expect(img).toHaveClass('test-class')
+    expect(img).toHaveAttribute('data-testid', 'test-id')
+  })
+})

--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Box, CircularProgress } from '@mui/material'
+
+interface LazyImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string
+  alt: string
+  width?: number | string
+  height?: number | string
+  priority?: boolean
+}
+
+const LazyImage: React.FC<LazyImageProps> = ({
+  src,
+  alt,
+  width,
+  height,
+  priority = false,
+  ...props
+}) => {
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [error, setError] = React.useState(false)
+
+  return (
+    <Box
+      position='relative'
+      display='inline-block'
+      width={width}
+      height={height}
+      data-testid='lazy-image-container'
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        loading={priority ? 'eager' : 'lazy'}
+        decoding='async'
+        onLoad={() => setIsLoading(false)}
+        onError={() => setError(true)}
+        style={{
+          opacity: isLoading ? 0 : 1,
+          transition: 'opacity 0.2s',
+          objectFit: 'cover',
+          width: '100%',
+          height: '100%',
+        }}
+        {...props}
+      />
+      {isLoading && !error && (
+        <Box
+          position='absolute'
+          top='50%'
+          left='50%'
+          sx={{
+            transform: 'translate(-50%, -50%)',
+          }}
+        >
+          <CircularProgress size={20} />
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default LazyImage

--- a/src/components/ProfileCard.test.tsx
+++ b/src/components/ProfileCard.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import ProfileCard from './ProfileCard'
+
+// Mock LazyImage component
+vi.mock('./LazyImage', () => ({
+  default: ({ src, alt }) => <img src={src} alt={alt} data-testid='lazy-image' />,
+}))
 
 describe('ProfileCard', () => {
   it('renders profile information correctly', () => {
@@ -15,11 +20,12 @@ describe('ProfileCard', () => {
     render(<ProfileCard {...testProps} />)
 
     // Assert
-    const avatar = screen.getByAltText(`${testProps.name}'s profile picture`)
+    const image = screen.getByTestId('lazy-image')
     const roleText = screen.getByText(testProps.role)
 
-    expect(avatar).toBeInTheDocument()
-    expect(avatar).toHaveAttribute('src', testProps.image)
+    expect(image).toBeInTheDocument()
+    expect(image).toHaveAttribute('src', testProps.image)
+    expect(image).toHaveAttribute('alt', `${testProps.name}'s profile picture`)
     expect(roleText).toBeInTheDocument()
   })
 })

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,5 +1,6 @@
-import { Avatar, Box } from '@mui/material'
+import { Box } from '@mui/material'
 import React from 'react'
+import LazyImage from './LazyImage'
 
 type ProfileProps = {
   image: string
@@ -17,15 +18,16 @@ const ProfileCard: React.FC<ProfileProps> = ({ image, name, role }) => (
     style={{ margin: '1rem', padding: '1rem' }}
     data-testid='profile-card-component'
   >
-    <Avatar
-      alt={`${name}'s profile picture`}
-      src={image}
-      style={{ width: '200px', height: '200px' }}
-      imgProps={{
-        loading: 'eager',
-        decoding: 'async',
+    <Box
+      sx={{
+        borderRadius: '50%',
+        overflow: 'hidden',
+        width: 200,
+        height: 200,
       }}
-    />
+    >
+      <LazyImage src={image} alt={`${name}'s profile picture`} width={200} height={200} priority />
+    </Box>
     <Box component='header' style={{ textAlign: 'center', marginTop: '1rem' }}>
       <p>{role}</p>
     </Box>


### PR DESCRIPTION
This PR implements native lazy loading for images while ensuring above-the-fold content loads eagerly.
### Changes:

- New LazyImage component with loading states
- Updated ProfileCard to use optimized loading
- Added tests for loading behaviors
- Prevents layout shifts via width/height props