### PR TITLE
fix: use correct push command for tag deploys

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -135,8 +135,7 @@ jobs:
         if: steps.should_bump.outputs.skip == 'false'
         run: |
           git tag "v${{ steps.new_version.outputs.version }}"
-          git push
-          git push --tags
+          git push origin HEAD:main --tags
 
       - name: Create GitHub Release
         if: steps.should_bump.outputs.skip == 'false'


### PR DESCRIPTION
This PR fixes the deployment trigger by combining git push operations.

## Problem
- Separate push commands caused race condition
- Tag events processed before code was available
- Deployments failed to trigger

## Fix
- Use single atomic push command
- Ensures code and tag arrive together
- Guarantees deployment workflow triggers