### PR TITLE
fix: add push permissions for deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'pull_request'
 
     steps:
       - name: Checkout

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR fixes deployment failures by adding conditional CI execution and PAT authentication.
### Changes

- Add conditional logic to test job (tags + PRs only)
- Add PAT token to version workflow checkout

### Impact

- Deployments now run on tag pushes
- Version workflow can push commits/tags
- Reduces unnecessary CI runs