### PR TITLE
fix: ensure changelog only updates in ci

### DIFF
--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -2,6 +2,13 @@ import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
+if (!process.env.CI && !process.env.ALLOW_LOCAL_CHANGELOG) {
+  console.error(
+    'Changelog generation is only allowed in CI. Set ALLOW_LOCAL_CHANGELOG=1 to override.',
+  )
+  process.exit(1)
+}
+
 export interface CommitInfo {
   hash: string
   type: string


### PR DESCRIPTION
This PR restricts changelog generation to CI.
### Details

- Adds a guard to generate-changelog.ts:
- Only runs if CI or `ALLOW_LOCAL_CHANGELOG` is set.
- Prevents accidental local changelog updates.
- Local override possible with `ALLOW_LOCAL_CHANGELOG=1`.