### PR TITLE
feat: update heading structure on home page

### DIFF
--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -8,7 +8,7 @@ type Achievements = {
 const Achievements: React.FC<Achievements> = ({ achievements }) => (
   <Card style={{ marginTop: 16 }}>
     <CardContent>
-      <Typography variant='h5' gutterBottom>
+      <Typography variant='h5' gutterBottom component='h2'>
         Achievements
       </Typography>
       {achievements.map((achievement, key) => (

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -11,10 +11,10 @@ type Education = {
 const Education: React.FC<Education> = ({ degree, school, duration, details }) => (
   <Card style={{ marginTop: 16 }}>
     <CardContent>
-      <Typography variant='h5' gutterBottom>
+      <Typography variant='h5' gutterBottom component='h2'>
         {degree}
       </Typography>
-      <Typography variant='subtitle1' color='textSecondary'>
+      <Typography variant='subtitle1' color='textSecondary' component='p'>
         {school} - {duration}
       </Typography>
       <Box marginTop={2}>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -25,10 +25,10 @@ const Experience: React.FC<Experience> = ({ title, company, duration, bullets })
     />
     <Card style={{ marginTop: 16 }}>
       <CardContent>
-        <Typography variant='h5' gutterBottom>
+        <Typography variant='h5' gutterBottom component='h2'>
           {title}
         </Typography>
-        <Typography variant='subtitle1' color='textSecondary'>
+        <Typography variant='subtitle1' color='textSecondary' component='p'>
           {company} - {duration}
         </Typography>
         {bullets.map((bullet, key) => (

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -12,7 +12,7 @@ type Skills = {
 const Skills: React.FC<Skills> = ({ skills }) => (
   <Card style={{ marginTop: 16 }}>
     <CardContent>
-      <Typography variant='h5' gutterBottom id='skills-heading'>
+      <Typography variant='h5' gutterBottom component='h2' id='skills-heading'>
         Skills
       </Typography>
       {skills.map((skill, index) => (


### PR DESCRIPTION
This PR updates home page heading markup for better semantic structure.
### Changes

- Promotes Skills, Achievements, Experience, and Education headings to H2
- Company and school info now use paragraph tags

### Notes

- No visual changes
- Improves accessibility and SEO