### PR TITLE
feat: lazy load blog post components

### DIFF
--- a/src/components/BlogPost.test.tsx
+++ b/src/components/BlogPost.test.tsx
@@ -56,16 +56,23 @@ describe('BlogPost', () => {
     children: <div data-testid='blog-content'>Test blog content</div>,
   }
 
-  it('renders with all required components', () => {
+  it('renders with all required components and skeletons', () => {
     render(
       <BrowserRouter>
         <BlogPost {...defaultProps} />
       </BrowserRouter>,
     )
 
+    // Check for header (not lazy loaded)
     expect(screen.getByTestId('header')).toBeInTheDocument()
+
+    // Check for skeletons of lazy-loaded components
     expect(screen.getByTestId('profile-card')).toBeInTheDocument()
     expect(screen.getByTestId('recent-posts')).toBeInTheDocument()
+    expect(screen.getByTestId('bookmarked-posts')).toBeInTheDocument()
+    expect(screen.getByTestId('author-bio')).toBeInTheDocument()
+
+    // Check for blog content
     expect(screen.getByTestId('blog-content')).toBeInTheDocument()
   })
 

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, Suspense, lazy } from 'react'
 import { helmetJsonLdProp } from 'react-schemaorg'
 import { BlogPosting } from 'schema-dts'
 import {
@@ -18,16 +18,19 @@ import BookmarkIcon from '@mui/icons-material/Bookmark'
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import { Helmet } from 'react-helmet'
 import { useLocation } from 'react-router-dom'
-import Header from '../components/Header.tsx'
-import ProfileCard from '../components/ProfileCard.tsx'
-import RecentPosts from '../components/RecentPosts.tsx'
-import BookmarkedPosts from '../components/BookmarkedPosts.tsx'
-import AuthorBio from '../components/AuthorBio.tsx'
-import profileImage from '../assets/raymond-perez.jpg'
-import withCanonical from './WithCanonical.tsx'
+import Header from './Header'
+import LoadingSkeleton from './LoadingSkeleton'
+import withCanonical from './WithCanonical'
 import { PROFILE } from '../constants/profile'
 import { useBookmarks } from '../hooks/useBookmarks'
 import { calculateReadingTime, formatReadingTime } from '../utils/readingTime'
+import profileImage from '../assets/raymond-perez.jpg'
+
+// Lazy load below-the-fold components
+const ProfileCard = lazy(() => import('./ProfileCard'))
+const RecentPosts = lazy(() => import('./RecentPosts'))
+const BookmarkedPosts = lazy(() => import('./BookmarkedPosts'))
+const AuthorBio = lazy(() => import('./AuthorBio'))
 
 interface BlogPostProps {
   title: string
@@ -106,9 +109,15 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
           <Grid container spacing={2} direction='row-reverse' alignItems='flex-start'>
             <Grid item xs={12} lg={4}>
               <Header />
-              <ProfileCard image={profileImage} name={PROFILE.name} role={PROFILE.role} />
-              <BookmarkedPosts />
-              <RecentPosts />
+              <Suspense fallback={<LoadingSkeleton testId='profile-card' />}>
+                <ProfileCard image={profileImage} name={PROFILE.name} role={PROFILE.role} />
+              </Suspense>
+              <Suspense fallback={<LoadingSkeleton testId='bookmarked-posts' />}>
+                <BookmarkedPosts />
+              </Suspense>
+              <Suspense fallback={<LoadingSkeleton testId='recent-posts' />}>
+                <RecentPosts />
+              </Suspense>
             </Grid>
             <Grid item xs={12} lg={8}>
               <Box mb={2}>
@@ -146,7 +155,9 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
                 </Typography>
               </Box>
               {children}
-              <AuthorBio />
+              <Suspense fallback={<LoadingSkeleton testId='author-bio' />}>
+                <AuthorBio />
+              </Suspense>
             </Grid>
           </Grid>
         </Box>

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Box, Skeleton } from '@mui/material'
+
+interface LoadingSkeletonProps {
+  testId?: string
+}
+
+const LoadingSkeleton: React.FC<LoadingSkeletonProps> = ({ testId }) => {
+  return (
+    <Box sx={{ width: '100%', mb: 2 }} data-testid={testId}>
+      <Skeleton variant='rectangular' height={60} sx={{ mb: 1 }} />
+      <Skeleton variant='text' width='60%' height={24} sx={{ mb: 0.5 }} />
+      <Skeleton variant='text' width='40%' height={24} sx={{ mb: 0.5 }} />
+      <Skeleton variant='text' width='80%' height={24} />
+    </Box>
+  )
+}
+
+export default LoadingSkeleton


### PR DESCRIPTION
This PR implements lazy loading for below-the-fold components to improve LCP scores.

## Changes
- Added LoadingSkeleton component for visual feedback
- Converted ProfileCard, RecentPosts, BookmarkedPosts, and AuthorBio to lazy imports
- Wrapped components in Suspense boundaries with skeleton fallbacks

## Benefits
- Reduces initial bundle size
- Prioritizes above-the-fold content loading
- Improves mobile performance
- Maintains visual continuity during loading

## Technical Details
- Uses React.lazy() for code splitting
- Material UI Skeleton components for loading states
- Keeps Header eagerly loaded (above-the-fold)
- Follows existing project patterns