### PR TITLE
feat: add share buttons to blog posts

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -25,6 +25,7 @@ import { PROFILE } from '../constants/profile'
 import { useBookmarks } from '../hooks/useBookmarks'
 import { calculateReadingTime, formatReadingTime } from '../utils/readingTime'
 import profileImage from '../assets/raymond-perez.jpg'
+import SocialShareButtons from './SocialShareButtons'
 
 // Lazy load below-the-fold components
 const ProfileCard = lazy(() => import('./ProfileCard'))
@@ -149,6 +150,7 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
                   </IconButton>
                 </Tooltip>
               </Box>
+              <SocialShareButtons title={title} />
               <Box mb={2}>
                 <Typography variant='body2' color='text.secondary'>
                   {readingTimeDisplay}

--- a/src/components/SocialShareButtons.test.tsx
+++ b/src/components/SocialShareButtons.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import SocialShareButtons from './SocialShareButtons'
+import { describe, it, beforeAll, afterAll, beforeEach, vi, expect } from 'vitest'
+
+describe('SocialShareButtons', () => {
+  const mockOpen = vi.fn()
+  let originalHref: string
+  beforeAll(() => {
+    originalHref = window.location.href
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: 'https://example.com/post' },
+    })
+    window.open = mockOpen
+  })
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: originalHref },
+    })
+    window.open = undefined
+  })
+  beforeEach(() => {
+    mockOpen.mockClear()
+  })
+
+  it('renders all three share buttons with correct aria-labels', () => {
+    render(<SocialShareButtons title='Test Post' />)
+    expect(screen.getByLabelText('Share on Twitter')).toBeInTheDocument()
+    expect(screen.getByLabelText('Share on LinkedIn')).toBeInTheDocument()
+    expect(screen.getByLabelText('Share on Facebook')).toBeInTheDocument()
+  })
+
+  it('clicking a button opens the correct share URL', () => {
+    render(<SocialShareButtons title='Test Post' />)
+    fireEvent.click(screen.getByLabelText('Share on Twitter'))
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.stringContaining('https://twitter.com/intent/tweet'),
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('share URLs include the correct title and URL', () => {
+    render(<SocialShareButtons title='Test Post' />)
+    fireEvent.click(screen.getByLabelText('Share on Twitter'))
+    const url = mockOpen.mock.calls[0][0]
+    expect(url).toContain(encodeURIComponent('Test Post'))
+    expect(url).toContain(encodeURIComponent('https://example.com/post'))
+  })
+})

--- a/src/components/SocialShareButtons.tsx
+++ b/src/components/SocialShareButtons.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Box, IconButton, Tooltip } from '@mui/material'
+import TwitterIcon from '@mui/icons-material/Twitter'
+import LinkedInIcon from '@mui/icons-material/LinkedIn'
+import FacebookIcon from '@mui/icons-material/Facebook'
+
+interface SocialShareButtonsProps {
+  title: string
+}
+
+const getShareUrl = (platform: 'twitter' | 'linkedin' | 'facebook', title: string, url: string) => {
+  const encodedUrl = encodeURIComponent(url)
+  const encodedTitle = encodeURIComponent(title)
+  switch (platform) {
+    case 'twitter':
+      return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`
+    case 'linkedin':
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`
+    case 'facebook':
+      return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`
+    default:
+      return '#'
+  }
+}
+
+const SocialShareButtons: React.FC<SocialShareButtonsProps> = ({ title }) => {
+  const url = typeof window !== 'undefined' ? window.location.href : ''
+
+  const handleShare = (platform: 'twitter' | 'linkedin' | 'facebook') => {
+    const shareUrl = getShareUrl(platform, title, url)
+    window.open(shareUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <Box display='flex' gap={1} mb={2}>
+      <Tooltip title='Share on Twitter'>
+        <IconButton
+          aria-label='Share on Twitter'
+          onClick={() => handleShare('twitter')}
+          size='small'
+        >
+          <TwitterIcon fontSize='small' />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title='Share on LinkedIn'>
+        <IconButton
+          aria-label='Share on LinkedIn'
+          onClick={() => handleShare('linkedin')}
+          size='small'
+        >
+          <LinkedInIcon fontSize='small' />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title='Share on Facebook'>
+        <IconButton
+          aria-label='Share on Facebook'
+          onClick={() => handleShare('facebook')}
+          size='small'
+        >
+          <FacebookIcon fontSize='small' />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  )
+}
+
+export default SocialShareButtons


### PR DESCRIPTION
This PR adds social share buttons to blog posts.

#### Changes
- Adds Twitter, LinkedIn, Facebook share buttons
- Places buttons below post title
- Includes accessibility labels

#### Tests
- Renders all buttons
- Verifies share URLs
- Checks click behavior