### PR TITLE
feat: convert h3 headings for articles

### DIFF
--- a/src/pages/articles/WhyGraphQL.tsx
+++ b/src/pages/articles/WhyGraphQL.tsx
@@ -42,7 +42,7 @@ const WhyGraphQL = (): React.ReactElement => {
               />
             </ListItem>
           </List>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             I. Introduction
           </Typography>
           <Typography paragraph>
@@ -52,7 +52,7 @@ const WhyGraphQL = (): React.ReactElement => {
             why, in my experience, I've found myself leaning more towards GraphQL.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             II. Flexibility and Adaptability
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -108,7 +108,7 @@ const WhyGraphQL = (): React.ReactElement => {
 }`}
           </LazySyntaxHighlighter>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             III. Simplified API Structure
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -135,7 +135,7 @@ const WhyGraphQL = (): React.ReactElement => {
             services, providing a single point of access for all your data needs.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IV. Performance Benefits
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -180,7 +180,7 @@ const WhyGraphQL = (): React.ReactElement => {
 }`}
           </LazySyntaxHighlighter>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             V. Client-Side Development Advantages
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -221,7 +221,7 @@ const WhyGraphQL = (): React.ReactElement => {
 }`}
           </LazySyntaxHighlighter>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VI. Security and Error Handling
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -282,7 +282,7 @@ if (!user.canSeePost(postId)) {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VII. Use Cases for GraphQL
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -330,7 +330,7 @@ if (!user.canSeePost(postId)) {
             requirements.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VIII. Drawbacks and Considerations
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -365,7 +365,7 @@ if (!user.canSeePost(postId)) {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IX. Comparing GraphQL and REST
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -420,7 +420,7 @@ if (!user.canSeePost(postId)) {
 }`}
           </LazySyntaxHighlighter>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             X. Conclusion
           </Typography>
           <Typography paragraph>

--- a/src/pages/articles/WhyInertia.tsx
+++ b/src/pages/articles/WhyInertia.tsx
@@ -35,7 +35,7 @@ const WhyInertia = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Background
           </Typography>
 
@@ -53,7 +53,7 @@ const WhyInertia = (): React.ReactElement => {
             applications. Let me explain why.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             What Is Inertia.js?
           </Typography>
 
@@ -95,7 +95,7 @@ npm install @inertiajs/react`}
             </LazySyntaxHighlighter>
           </Paper>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Why It Resonates (Personally)
           </Typography>
 
@@ -142,7 +142,7 @@ class UserController extends Controller
             productive from day one while continuously improving my skills.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             How It Changes Development
           </Typography>
 
@@ -279,7 +279,7 @@ export default function CreateUser() {
             </LazySyntaxHighlighter>
           </Paper>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Possible Drawbacks
           </Typography>
 
@@ -348,7 +348,7 @@ return Inertia::render('Dashboard', [
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Community Perspectives
           </Typography>
 
@@ -379,7 +379,7 @@ return Inertia::render('Dashboard', [
             leverage their existing skills while gradually learning new ones.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Practical Differences vs. "Vanilla" React
           </Typography>
 
@@ -538,7 +538,7 @@ export default function Users({ users }: Props) {
             </LazySyntaxHighlighter>
           </Paper>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Takeaways
           </Typography>
 
@@ -573,7 +573,7 @@ export default function Users({ users }: Props) {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Questions to Consider
           </Typography>
 


### PR DESCRIPTION
This PR converts h4 headings to h3 in WhyInertia.tsx and WhyGraphQL.tsx to improve table of contents navigation.

### Changes

- WhyInertia.tsx: 9 h4 → h3 conversions
- WhyGraphQL.tsx: 10 h4 → h3 conversions

### Impact

- TOC items increase from 3 to 9-10 per article
- Better navigation for long articles (732 and 525 lines)
- Consistent heading hierarchy across articles