### PR TITLE
feat: add proper heading for why laravel article

### DIFF
--- a/src/pages/articles/WhyLaravel.tsx
+++ b/src/pages/articles/WhyLaravel.tsx
@@ -62,7 +62,7 @@ const WhyLaravel = (): React.ReactElement => {
             choice for your next project.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             II. Ease of Use and Rapid Development
           </Typography>
 
@@ -121,7 +121,7 @@ const WhyLaravel = (): React.ReactElement => {
             Laravel community.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             III. Powerful Built-In Features
           </Typography>
 
@@ -194,7 +194,7 @@ const WhyLaravel = (): React.ReactElement => {
             ensure that your code is clean, maintainable, and scalable.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IV. Flexibility and Customization
           </Typography>
 
@@ -258,7 +258,7 @@ const WhyLaravel = (): React.ReactElement => {
             team's coding standards.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             V. Strong Community and Ecosystem
           </Typography>
 
@@ -301,7 +301,7 @@ const WhyLaravel = (): React.ReactElement => {
             application, Laravel has the tools and resources to help you succeed.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VI. Security and Performance
           </Typography>
 
@@ -362,7 +362,7 @@ const WhyLaravel = (): React.ReactElement => {
             for building robust and high-performing web applications.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VII. Comparison with Other Frameworks
           </Typography>
 
@@ -403,7 +403,7 @@ const WhyLaravel = (): React.ReactElement => {
             your project best.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VIII. Conclusion
           </Typography>
 


### PR DESCRIPTION
This PR converts 7 h4 headings to h3 in WhyLaravel.tsx to improve table of contents navigation.
### Changes

- Convert main section headings from h4 to h3
- Maintains existing content structure
- Improves TOC functionality for 485-line article

### Impact

- Better navigation for long articles
- Consistent heading hierarchy
- Enhanced accessibility for screen readers