### PR TITLE
feat: convert headings for why opinionated and typescript

### DIFF
--- a/src/pages/articles/WhyOpinionated.tsx
+++ b/src/pages/articles/WhyOpinionated.tsx
@@ -44,7 +44,7 @@ const WhyOpinionated = (): React.ReactElement => {
             distinction is crucial, as it sets the stage for how projects are built and maintained.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             The Engineering Analogy
           </Typography>
           <Typography variant='body1' paragraph>
@@ -63,7 +63,7 @@ const WhyOpinionated = (): React.ReactElement => {
             minimizes risk but also fosters a sense of security and confidence in the final product.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Benefits of Opinionated Frameworks
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -132,7 +132,7 @@ const WhyOpinionated = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Laravel as a Case Study
           </Typography>
           <Typography variant='body1' paragraph>
@@ -196,7 +196,7 @@ const WhyOpinionated = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Addressing Criticisms
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -248,7 +248,7 @@ const WhyOpinionated = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Lessons from Traditional Engineering
           </Typography>
           <Typography variant='h6' gutterBottom>
@@ -287,7 +287,7 @@ const WhyOpinionated = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             Conclusion
           </Typography>
           <Typography variant='body1' paragraph>

--- a/src/pages/articles/WhyTypescript.tsx
+++ b/src/pages/articles/WhyTypescript.tsx
@@ -26,7 +26,7 @@ const WhyTypeScript = (): React.ReactElement => {
             </ListItem>
           </List>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             I. Introduction
           </Typography>
           <Typography paragraph>
@@ -37,7 +37,7 @@ const WhyTypeScript = (): React.ReactElement => {
             typed superset of JavaScript that adds optional types to the language.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             II. Benefits of TypeScript
           </Typography>
 
@@ -181,7 +181,7 @@ add("Hello", 5);`}
             available to enhance error readability, making the debugging process much smoother.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             III. Addressing Common Concerns
           </Typography>
 
@@ -218,7 +218,7 @@ add("Hello", 5);`}
             daunting option for teams considering making the switch.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IV. Real-World Applications and Success Stories
           </Typography>
 
@@ -244,7 +244,7 @@ add("Hello", 5);`}
             JavaScript.
           </Typography>
 
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             V. Conclusion
           </Typography>
           <Typography paragraph>


### PR DESCRIPTION
This PR standardizes heading hierarchies in two articles.
### Changes

- Convert 6 h4 → h3 headings in WhyOpinionated.tsx
- Convert 5 h4 → h3 headings in WhyTypescript.tsx

### Impact

- Improves TOC navigation for 2 articles (743 lines total)
- Increases TOC items from 7 to 11 across both articles