### PR TITLE
feat: convert headings for why webdev and why nest

### DIFF
--- a/src/pages/articles/WhyNest.tsx
+++ b/src/pages/articles/WhyNest.tsx
@@ -66,7 +66,7 @@ const WhyNest = (): React.ReactElement => {
 
           <Divider sx={{ my: 4 }} />
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             I. Introduction
           </Typography>
           <Typography paragraph>
@@ -77,7 +77,7 @@ const WhyNest = (): React.ReactElement => {
             reasons why I, as a developer, choose NestJS over other frameworks.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             II. Structured and Opinionated Framework
           </Typography>
           <Typography paragraph>
@@ -109,7 +109,7 @@ const WhyNest = (): React.ReactElement => {
             understand, especially when the application starts to grow.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             III. TypeScript Integration
           </Typography>
           <Typography paragraph>
@@ -134,7 +134,7 @@ const WhyNest = (): React.ReactElement => {
             integration makes NestJS a joy to work with.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IV. Dependency Injection
           </Typography>
           <Typography paragraph>
@@ -159,7 +159,7 @@ const WhyNest = (): React.ReactElement => {
             version for testing or a different implementation for different environments.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             V. Modularity and Scalability
           </Typography>
           <Typography paragraph>
@@ -186,7 +186,7 @@ const WhyNest = (): React.ReactElement => {
             of responsibilities makes the code easier to understand and maintain.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VI. Comprehensive Documentation and Community Support
           </Typography>
           <Typography paragraph>
@@ -201,7 +201,7 @@ const WhyNest = (): React.ReactElement => {
             and community support invaluable.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VII. Built-in Features and Best Practices
           </Typography>
           <Typography paragraph>
@@ -229,7 +229,7 @@ const WhyNest = (): React.ReactElement => {
             these best practices are built in, so you can focus on writing your business logic.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VIII. Ease of Onboarding for New Developers
           </Typography>
           <Typography paragraph>
@@ -245,7 +245,7 @@ const WhyNest = (): React.ReactElement => {
             appreciate the flexibility and power that NestJS offers.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IX. Addressing Common Criticisms
           </Typography>
           <Typography paragraph>
@@ -265,7 +265,7 @@ const WhyNest = (): React.ReactElement => {
             outweigh these potential drawbacks.
           </Typography>
 
-          <Typography variant='h6' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             X. Conclusion
           </Typography>
           <Typography paragraph>

--- a/src/pages/articles/WhyWebDev.tsx
+++ b/src/pages/articles/WhyWebDev.tsx
@@ -43,7 +43,7 @@ const WhyWebDev = (): React.ReactElement => {
             potential to make a significant impact. In this post, I'll delve into why web
             development is an ideal career choice for me and potentially for you too.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             II. Accessibility and Low Barrier to Entry
           </Typography>
           <Typography variant='body1' paragraph>
@@ -76,7 +76,7 @@ const WhyWebDev = (): React.ReactElement => {
             In essence, the low barrier to entry and the abundance of learning resources make web
             development an accessible career choice.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             III. High Demand and Lucrative Salaries
           </Typography>
           <Typography variant='body1' paragraph>
@@ -106,7 +106,7 @@ const WhyWebDev = (): React.ReactElement => {
             In summary, the high demand, competitive salaries, and the potential to make a
             significant impact make web development a rewarding career choice.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             IV. Versatility and Creative Freedom
           </Typography>
           <Typography variant='body1' paragraph>
@@ -136,7 +136,7 @@ const WhyWebDev = (): React.ReactElement => {
             In a nutshell, the versatility of projects, the opportunity for creativity, and the
             constant learning and innovation make web development a dynamic and fulfilling career.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             V. Work-Life Balance and Flexibility
           </Typography>
           <Typography variant='body1' paragraph>
@@ -162,7 +162,7 @@ const WhyWebDev = (): React.ReactElement => {
             attractive career option, especially for those who value autonomy and the ability to
             work on their own terms.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VI. Impact and Contribution
           </Typography>
           <Typography variant='body1' paragraph>
@@ -188,7 +188,7 @@ const WhyWebDev = (): React.ReactElement => {
             designing a user-friendly interface, your work can have a profound impact on the
             end-users.
           </Typography>
-          <Typography variant='h4' gutterBottom>
+          <Typography variant='h3' gutterBottom>
             VII. Conclusion
           </Typography>
           <Typography variant='body1' paragraph>


### PR DESCRIPTION
This PR standardizes heading hierarchies in two articles.
### Changes

- WhyWebDev.tsx: Convert 6 h4 → h3 headings
- WhyNest.tsx: Convert 10 h6 → h3 headings

### Impact

- Improves TOC navigation from 2 items to 6+ items per article
- Ensures consistent heading structure across all articles