### PR TITLE
fix: use router link to for redirect issues

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -135,7 +135,7 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
             <Grid item xs={12} lg={8}>
               <Box mb={2}>
                 <Breadcrumbs aria-label='breadcrumb'>
-                  <Link color='inherit' href='/'>
+                  <Link component={RouterLink} color='inherit' to='/'>
                     Home
                   </Link>
                   <Typography color='textPrimary'>{title}</Typography>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, Link, Typography } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import React from 'react'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 
@@ -23,7 +24,13 @@ const Summary: React.FC = () => (
         technology solutions. I specialize in full-stack development with expertise in PHP
         (Laravel), React, Node.js, and cloud infrastructure (AWS, Datadog, New Relic). I build
         scalable applications using{' '}
-        <Link href='/why-opinionated' key='/why-opinionated' color='primary' underline='hover'>
+        <Link
+          component={RouterLink}
+          to='/why-opinionated'
+          key='/why-opinionated'
+          color='primary'
+          underline='hover'
+        >
           opinionated frameworks
         </Link>{' '}
         and modern development practices. I actively contribute to entrepreneurial communities and


### PR DESCRIPTION
This PR replaces internal MUI Link href with RouterLink to ensure client-side navigation and fix redirect issues.
### Changes

- BlogPost.tsx: Breadcrumbs Home → RouterLink
- Summary.tsx: '/why-opinionated' link → RouterLink

### Impact

- Avoids full reloads; fixes redirect issues