### PR TITLE
feat: implement persistent layout

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,9 +20,10 @@ vi.mock('react-router-dom', () => {
   return {
     BrowserRouter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     Routes: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Route: ({ path, element }: { path: string; element: React.ReactNode }) => (
-      <div data-testid={`route-${path}`}>{element}</div>
+    Route: ({ path, element }: { path?: string; element?: React.ReactNode }) => (
+      <div data-testid={`route-${path ?? 'layout'}`}>{element}</div>
     ),
+    Outlet: () => <div data-testid='outlet' />,
     useNavigate: () => navigate,
     Link: ({
       children,
@@ -41,23 +42,12 @@ vi.mock('./components/LoadingFallback', () => ({
 describe('App', () => {
   it('renders without crashing', () => {
     render(<App />)
-    expect(screen.getByTestId('route-/')).toBeInTheDocument()
+    expect(screen.getByTestId('route-layout')).toBeInTheDocument()
   })
 
   it('renders all routes', () => {
     render(<App />)
-    expect(screen.getByTestId('route-/')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-mvc-pattern')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-nestjs')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-graphql')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-nodejs')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-typescript')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-react')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-laravel')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-inertia')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-oop')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-web-development')).toBeInTheDocument()
-    expect(screen.getByTestId('route-/why-opinionated')).toBeInTheDocument()
+    expect(screen.getByTestId('route-layout')).toBeInTheDocument()
     expect(screen.getByTestId('route-*')).toBeInTheDocument()
   })
 

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -8,6 +8,7 @@ import { posts } from '../constants/posts'
 import Home from '../pages/Home'
 import NotFound from '../pages/NotFound'
 import HashRedirectHandler from './HashRedirectHandler'
+import SiteLayout from './SiteLayout'
 
 const AppContent: React.FC = () => {
   const { theme } = useTheme()
@@ -19,10 +20,12 @@ const AppContent: React.FC = () => {
         <HashRedirectHandler />
         <Suspense fallback={<LoadingFallback />}>
           <Routes>
-            <Route path='/' element={<Home />} />
-            {posts.map((post) => (
-              <Route key={post.path} path={post.path} element={<post.Component />} />
-            ))}
+            <Route element={<SiteLayout />}>
+              <Route path='/' element={<Home />} />
+              {posts.map((post) => (
+                <Route key={post.path} path={post.path} element={<post.Component />} />
+              ))}
+            </Route>
             <Route path='*' element={<NotFound />} />
           </Routes>
         </Suspense>

--- a/src/components/BlogPost.test.tsx
+++ b/src/components/BlogPost.test.tsx
@@ -30,17 +30,9 @@ vi.mock('react-helmet', () => ({
   ),
 }))
 
-vi.mock('./Header', () => ({
-  default: () => <div data-testid='header'>Header Component</div>,
-}))
+// Header lives in layout now; no need to assert it here
 
-vi.mock('./ProfileCard', () => ({
-  default: () => <div data-testid='profile-card'>Profile Card Component</div>,
-}))
-
-vi.mock('./RecentPosts', () => ({
-  default: () => <div data-testid='recent-posts'>Recent Posts Component</div>,
-}))
+// Sidebar components moved to layout; not rendered by BlogPost directly
 
 vi.mock('./TableOfContents', () => ({
   default: () => <div data-testid='table-of-contents'>Table of Contents Component</div>,
@@ -75,14 +67,8 @@ describe('BlogPost', () => {
       </BrowserRouter>,
     )
 
-    // Check for header (not lazy loaded)
-    expect(screen.getByTestId('header')).toBeInTheDocument()
-
-    // Check for skeletons of lazy-loaded components
-    expect(screen.getByTestId('profile-card')).toBeInTheDocument()
+    // Check for skeletons of lazy-loaded components rendered by BlogPost
     expect(screen.getByTestId('table-of-contents')).toBeInTheDocument()
-    expect(screen.getByTestId('recent-posts')).toBeInTheDocument()
-    expect(screen.getByTestId('bookmarked-posts')).toBeInTheDocument()
     expect(screen.getByTestId('author-bio')).toBeInTheDocument()
 
     // Check for blog content

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -1,24 +1,12 @@
 import React, { useState, useEffect, Suspense, lazy } from 'react'
 import { helmetJsonLdProp } from 'react-schemaorg'
 import { BlogPosting } from 'schema-dts'
-import {
-  Container,
-  CssBaseline,
-  Box,
-  Grid,
-  Typography,
-  Link,
-  Breadcrumbs,
-  Fab,
-  IconButton,
-  Tooltip,
-} from '@mui/material'
+import { Box, Typography, Link, Breadcrumbs, Fab, IconButton, Tooltip } from '@mui/material'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import BookmarkIcon from '@mui/icons-material/Bookmark'
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder'
 import { Helmet } from 'react-helmet'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
-import Header from './Header'
 import LoadingSkeleton from './LoadingSkeleton'
 import withCanonical from './WithCanonical'
 import { PROFILE } from '../constants/profile'
@@ -28,10 +16,6 @@ import profileImage from '../assets/raymond-perez.jpg'
 import SocialShareButtons from './SocialShareButtons'
 import { posts } from '../constants/posts'
 
-// Lazy load below-the-fold components
-const ProfileCard = lazy(() => import('./ProfileCard'))
-const RecentPosts = lazy(() => import('./RecentPosts'))
-const BookmarkedPosts = lazy(() => import('./BookmarkedPosts'))
 const AuthorBio = lazy(() => import('./AuthorBio'))
 const TableOfContents = lazy(() => import('./TableOfContents'))
 
@@ -116,140 +100,112 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
           {title} - {PROFILE.name} - {PROFILE.role}
         </title>
       </Helmet>
-      <Container maxWidth={false}>
-        <CssBaseline />
-        <Box my={2}>
-          <Grid container spacing={2} direction='row-reverse' alignItems='flex-start'>
-            <Grid item xs={12} lg={4}>
-              <Header />
-              <Suspense fallback={<LoadingSkeleton testId='profile-card' />}>
-                <ProfileCard image={profileImage} name={PROFILE.name} role={PROFILE.role} />
-              </Suspense>
-              <Suspense fallback={<LoadingSkeleton testId='bookmarked-posts' />}>
-                <BookmarkedPosts />
-              </Suspense>
-              <Suspense fallback={<LoadingSkeleton testId='recent-posts' />}>
-                <RecentPosts />
-              </Suspense>
-            </Grid>
-            <Grid item xs={12} lg={8}>
-              <Box mb={2}>
-                <Breadcrumbs aria-label='breadcrumb'>
-                  <Link color='inherit' href='/'>
-                    Home
-                  </Link>
-                  <Typography color='textPrimary'>{title}</Typography>
-                </Breadcrumbs>
-              </Box>
-              <Box display='flex' alignItems='center' justifyContent='space-between' mb={2}>
-                <Typography variant='h2' component='h1' sx={{ flexGrow: 1 }}>
-                  {title}
-                </Typography>
-                <Tooltip title={isCurrentlyBookmarked ? 'Remove Bookmark' : 'Bookmark Article'}>
-                  <IconButton
-                    onClick={handleBookmarkClick}
-                    aria-label={isCurrentlyBookmarked ? 'remove bookmark' : 'bookmark article'}
-                    sx={{
-                      color: isCurrentlyBookmarked ? 'primary.main' : 'text.secondary',
-                      ml: 2,
-                      '&:hover': {
-                        color: 'primary.main',
-                        bgcolor: 'action.hover',
-                      },
-                    }}
-                  >
-                    {isCurrentlyBookmarked ? <BookmarkIcon /> : <BookmarkBorderIcon />}
-                  </IconButton>
-                </Tooltip>
-              </Box>
-              <SocialShareButtons title={title} />
-              <Box mb={2}>
-                <Typography variant='body2' color='text.secondary'>
-                  {readingTimeDisplay}
-                </Typography>
-              </Box>
-              <Suspense fallback={<LoadingSkeleton testId='table-of-contents' />}>
-                <TableOfContents />
-              </Suspense>
-              {children}
-              <Suspense fallback={<LoadingSkeleton testId='author-bio' />}>
-                <AuthorBio />
-              </Suspense>
-              {/* Previous/Next Navigation */}
-              {(prevPost || nextPost) && (
-                <Box
-                  mt={6}
-                  mb={2}
-                  display='flex'
-                  justifyContent='space-between'
-                  alignItems='center'
-                >
-                  {prevPost ? (
-                    <Box>
-                      <Typography variant='caption' color='text.secondary'>
-                        Previous
-                      </Typography>
-                      <Link
-                        component={RouterLink}
-                        to={prevPost.path}
-                        underline='hover'
-                        color='primary'
-                        sx={{ display: 'block', fontWeight: 500 }}
-                      >
-                        {prevPost.title}
-                      </Link>
-                    </Box>
-                  ) : (
-                    <span />
-                  )}
-                  {nextPost ? (
-                    <Box textAlign='right'>
-                      <Typography variant='caption' color='text.secondary'>
-                        Next
-                      </Typography>
-                      <Link
-                        component={RouterLink}
-                        to={nextPost.path}
-                        underline='hover'
-                        color='primary'
-                        sx={{ display: 'block', fontWeight: 500 }}
-                      >
-                        {nextPost.title}
-                      </Link>
-                    </Box>
-                  ) : (
-                    <span />
-                  )}
-                </Box>
-              )}
-            </Grid>
-          </Grid>
-        </Box>
-        {showBackToTop && (
-          <Fab
-            size='small'
-            onClick={scrollToTop}
-            aria-label='back to top'
+      <Box mb={2}>
+        <Breadcrumbs aria-label='breadcrumb'>
+          <Link component={RouterLink} color='inherit' to='/'>
+            Home
+          </Link>
+          <Typography color='textPrimary'>{title}</Typography>
+        </Breadcrumbs>
+      </Box>
+      <Box display='flex' alignItems='center' justifyContent='space-between' mb={2}>
+        <Typography variant='h2' component='h1' sx={{ flexGrow: 1 }}>
+          {title}
+        </Typography>
+        <Tooltip title={isCurrentlyBookmarked ? 'Remove Bookmark' : 'Bookmark Article'}>
+          <IconButton
+            onClick={handleBookmarkClick}
+            aria-label={isCurrentlyBookmarked ? 'remove bookmark' : 'bookmark article'}
             sx={{
-              position: 'fixed',
-              bottom: 16,
-              right: 16,
-              bgcolor: 'background.paper',
-              color: 'text.secondary',
-              border: '1px solid',
-              borderColor: 'divider',
-              opacity: 0.8,
+              color: isCurrentlyBookmarked ? 'primary.main' : 'text.secondary',
+              ml: 2,
               '&:hover': {
-                opacity: 1,
+                color: 'primary.main',
                 bgcolor: 'action.hover',
-                borderColor: 'primary.main',
               },
             }}
           >
-            <KeyboardArrowUpIcon />
-          </Fab>
-        )}
-      </Container>
+            {isCurrentlyBookmarked ? <BookmarkIcon /> : <BookmarkBorderIcon />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <SocialShareButtons title={title} />
+      <Box mb={2}>
+        <Typography variant='body2' color='text.secondary'>
+          {readingTimeDisplay}
+        </Typography>
+      </Box>
+      <Suspense fallback={<LoadingSkeleton testId='table-of-contents' />}>
+        <TableOfContents />
+      </Suspense>
+      {children}
+      <Suspense fallback={<LoadingSkeleton testId='author-bio' />}>
+        <AuthorBio />
+      </Suspense>
+      {(prevPost || nextPost) && (
+        <Box mt={6} mb={2} display='flex' justifyContent='space-between' alignItems='center'>
+          {prevPost ? (
+            <Box>
+              <Typography variant='caption' color='text.secondary'>
+                Previous
+              </Typography>
+              <Link
+                component={RouterLink}
+                to={prevPost.path}
+                underline='hover'
+                color='primary'
+                sx={{ display: 'block', fontWeight: 500 }}
+              >
+                {prevPost.title}
+              </Link>
+            </Box>
+          ) : (
+            <span />
+          )}
+          {nextPost ? (
+            <Box textAlign='right'>
+              <Typography variant='caption' color='text.secondary'>
+                Next
+              </Typography>
+              <Link
+                component={RouterLink}
+                to={nextPost.path}
+                underline='hover'
+                color='primary'
+                sx={{ display: 'block', fontWeight: 500 }}
+              >
+                {nextPost.title}
+              </Link>
+            </Box>
+          ) : (
+            <span />
+          )}
+        </Box>
+      )}
+      {showBackToTop && (
+        <Fab
+          size='small'
+          onClick={scrollToTop}
+          aria-label='back to top'
+          sx={{
+            position: 'fixed',
+            bottom: 16,
+            right: 16,
+            bgcolor: 'background.paper',
+            color: 'text.secondary',
+            border: '1px solid',
+            borderColor: 'divider',
+            opacity: 0.8,
+            '&:hover': {
+              opacity: 1,
+              bgcolor: 'action.hover',
+              borderColor: 'primary.main',
+            },
+          }}
+        >
+          <KeyboardArrowUpIcon />
+        </Fab>
+      )}
     </React.Fragment>
   )
 }

--- a/src/components/RecentPosts.test.tsx
+++ b/src/components/RecentPosts.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import RecentPosts, { Post } from './RecentPosts'
+import { MemoryRouter } from 'react-router-dom'
 
 // Mock Material UI components to better control their behavior
 vi.mock('@mui/material', async () => {
@@ -26,7 +27,11 @@ describe('RecentPosts', () => {
     ]
 
     // Arrange
-    render(<RecentPosts posts={mockPosts} />)
+    render(
+      <MemoryRouter>
+        <RecentPosts posts={mockPosts} />
+      </MemoryRouter>,
+    )
 
     // Assert initial state (collapsed on mobile)
     const headerText = screen.getByText('Recent Posts')

--- a/src/components/RecentPosts.tsx
+++ b/src/components/RecentPosts.tsx
@@ -5,7 +5,6 @@ import {
   ListItem,
   ListItemText,
   Paper,
-  Link,
   Divider,
   Box,
   ListItemIcon,
@@ -15,6 +14,7 @@ import {
   useMediaQuery,
   Theme,
 } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import ArticleIcon from '@mui/icons-material/Article'
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -47,8 +47,8 @@ const PostItem = memo(({ post, index, theme }: PostItemProps) => {
     <React.Fragment>
       {index > 0 && <Divider component='li' variant='inset' />}
       <ListItem
-        component={Link}
-        href={post.path}
+        component={RouterLink}
+        to={post.path}
         sx={{
           py: 1.5,
           px: 2,

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -1,0 +1,40 @@
+import React, { Suspense, lazy } from 'react'
+import { Container, CssBaseline, Box, Grid } from '@mui/material'
+import { Outlet } from 'react-router-dom'
+import Header from './Header'
+import LoadingSkeleton from './LoadingSkeleton'
+import profileImage from '../assets/raymond-perez.jpg'
+import { PROFILE } from '../constants/profile'
+
+const ProfileCard = lazy(() => import('./ProfileCard'))
+const BookmarkedPosts = lazy(() => import('./BookmarkedPosts'))
+const RecentPosts = lazy(() => import('./RecentPosts'))
+
+const SiteLayout: React.FC = () => {
+  return (
+    <Container maxWidth={false}>
+      <CssBaseline />
+      <Box my={2}>
+        <Grid container spacing={2} direction='row-reverse' alignItems='flex-start'>
+          <Grid item xs={12} lg={4}>
+            <Header />
+            <Suspense fallback={<LoadingSkeleton testId='profile-card' />}>
+              <ProfileCard image={profileImage} name={PROFILE.name} role={PROFILE.role} />
+            </Suspense>
+            <Suspense fallback={<LoadingSkeleton testId='bookmarked-posts' />}>
+              <BookmarkedPosts />
+            </Suspense>
+            <Suspense fallback={<LoadingSkeleton testId='recent-posts' />}>
+              <RecentPosts />
+            </Suspense>
+          </Grid>
+          <Grid item xs={12} lg={8}>
+            <Outlet />
+          </Grid>
+        </Grid>
+      </Box>
+    </Container>
+  )
+}
+
+export default SiteLayout

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -2,29 +2,11 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import React from 'react'
 import Home from './Home'
-import { PROFILE } from '../constants/profile'
 import { BookmarkProvider } from '../contexts/BookmarkContext'
 
 // Mock the Helmet component
 vi.mock('react-helmet', () => ({
   Helmet: ({ children }) => <div data-testid='helmet-mock'>{children}</div>,
-}))
-
-// Mock the components used in Home
-vi.mock('../components/Header.tsx', () => ({
-  default: () => <div data-testid='header-component'>Header Mock</div>,
-}))
-
-vi.mock('../components/ProfileCard.tsx', () => ({
-  default: ({ name, role }) => (
-    <div data-testid='profile-card-component'>
-      Profile: {name} - {role}
-    </div>
-  ),
-}))
-
-vi.mock('../components/RecentPosts.tsx', () => ({
-  default: () => <div data-testid='recent-posts-component'>Recent Posts Mock</div>,
 }))
 
 vi.mock('../components/Summary.tsx', () => ({
@@ -59,28 +41,22 @@ vi.mock('../components/Education.tsx', () => ({
   ),
 }))
 
-vi.mock('../components/BookmarkedPosts.tsx', () => ({
-  default: () => <div data-testid='bookmarked-posts-component'>Bookmarked Posts Mock</div>,
-}))
+// BookmarkedPosts is provided by layout; Home no longer renders it directly
 
 const renderWithProvider = (component: React.ReactElement) => {
   return render(<BookmarkProvider>{component}</BookmarkProvider>)
 }
 
 describe('Home Component', () => {
-  it('renders profile information correctly', () => {
+  it('renders primary content correctly', () => {
     renderWithProvider(<Home />)
-
-    // Check for profile name and role
-    const profileCard = screen.getByTestId('profile-card-component')
-    expect(profileCard).toHaveTextContent(`Profile: ${PROFILE.name} - ${PROFILE.role}`)
+    expect(screen.getByTestId('summary-component')).toBeInTheDocument()
   })
 
   it('renders all main content sections', () => {
     renderWithProvider(<Home />)
 
-    // Verify all critical sections are present
-    expect(screen.getByTestId('header-component')).toBeInTheDocument()
+    // Verify main content sections are present
     expect(screen.getByTestId('summary-component')).toBeInTheDocument()
     expect(screen.getByTestId('skills-component')).toBeInTheDocument()
     expect(screen.getByTestId('achievements-component')).toBeInTheDocument()

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,11 +2,7 @@ import React from 'react'
 import { helmetJsonLdProp } from 'react-schemaorg'
 import { Person } from 'schema-dts'
 import profileImage from '../assets/raymond-perez.jpg'
-import { Container, CssBaseline, Box, Grid } from '@mui/material'
-import Header from '../components/Header.tsx'
-import ProfileCard from '../components/ProfileCard.tsx'
-import RecentPosts from '../components/RecentPosts.tsx'
-import BookmarkedPosts from '../components/BookmarkedPosts.tsx'
+import { Box } from '@mui/material'
 import Summary from '../components/Summary.tsx'
 import Links from '../components/Links.tsx'
 import Experience from '../components/Experience.tsx'
@@ -171,32 +167,18 @@ const Home: React.FC = () => {
         <link rel='canonical' href='https://www.rayperez.com' />
         <meta property='og:image' content={profileImage} />
       </Helmet>
-      <Container maxWidth={false}>
-        <CssBaseline />
-        <Box my={2}>
-          <Grid container spacing={2} direction='row-reverse' alignItems='flex-start'>
-            <Grid item xs={12} lg={4}>
-              <Header />
-              <ProfileCard image={profileImage} name={PROFILE.name} role={PROFILE.role} />
-              <BookmarkedPosts />
-              <RecentPosts />
-            </Grid>
-            <Grid item xs={12} lg={8}>
-              {/* Main content area headings and sections */}
-              <Summary />
-              <Links links={links} />
-              <Skills skills={SKILLS} />
-              <Achievements achievements={achievements} />
-              {experiences.map((exp, key) => (
-                <Experience {...exp} key={key} />
-              ))}
-              {educations.map((edu, key) => (
-                <Education {...edu} key={key} />
-              ))}
-            </Grid>
-          </Grid>
-        </Box>
-      </Container>
+      <Box>
+        <Summary />
+        <Links links={links} />
+        <Skills skills={SKILLS} />
+        <Achievements achievements={achievements} />
+        {experiences.map((exp, key) => (
+          <Experience {...exp} key={key} />
+        ))}
+        {educations.map((edu, key) => (
+          <Education {...edu} key={key} />
+        ))}
+      </Box>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
This PR implements a persistent layout using React Router so the sidebar stays mounted during navigation and internal links use client-side routing.

### Why
- Reduces unnecessary re-renders and full page reloads
- Preserves sidebar UI state (e.g., expand/collapse)

### Changes
- Added `SiteLayout` with `Header`, `ProfileCard`, `BookmarkedPosts`, `RecentPosts`, and `Outlet`
- Nested routes under the layout in `AppContent`
- Switched `href` to `RouterLink` in `RecentPosts` and `BlogPost` breadcrumb
- Removed sidebar from `Home` and `BlogPost`

### SEO
- Per-page `Helmet` and structured data remain unchanged

### Tests
- Updated affected tests; all pass