### PR TITLE
feat: add home link to footer

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -162,6 +162,19 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
           ) : (
             <span />
           )}
+          <Box>
+            <Link
+              component={RouterLink}
+              to='/'
+              underline='hover'
+              color='primary'
+              aria-label='back to home'
+              onClick={() => window.scrollTo({ top: 0 })}
+              sx={{ fontWeight: 500 }}
+            >
+              Back to Home
+            </Link>
+          </Box>
           {nextPost ? (
             <Box textAlign='right'>
               <Typography variant='caption' color='text.secondary'>


### PR DESCRIPTION
This PR integrates a Back to Home link into the article’s Previous/Next navigation and ensures it scrolls to the top on navigation.
### Changes

- Move link between Previous and Next in BlogPost
- Add onClick to scroll to top
- Remove separate centered footer link
- Keep MUI styling and routing patterns

### Rationale

- Matches existing navigation hierarchy
- Avoids preserved scroll when returning home
- Reduces visual clutter
