### PR TITLE
feat: add copy link button

### DIFF
--- a/src/components/SocialShareButtons.test.tsx
+++ b/src/components/SocialShareButtons.test.tsx
@@ -24,8 +24,9 @@ describe('SocialShareButtons', () => {
     mockOpen.mockClear()
   })
 
-  it('renders all three share buttons with correct aria-labels', () => {
+  it('renders all share buttons with correct aria-labels', () => {
     render(<SocialShareButtons title='Test Post' />)
+    expect(screen.getByLabelText('Copy link')).toBeInTheDocument()
     expect(screen.getByLabelText('Share on Twitter')).toBeInTheDocument()
     expect(screen.getByLabelText('Share on LinkedIn')).toBeInTheDocument()
     expect(screen.getByLabelText('Share on Facebook')).toBeInTheDocument()
@@ -47,5 +48,17 @@ describe('SocialShareButtons', () => {
     const url = mockOpen.mock.calls[0][0]
     expect(url).toContain(encodeURIComponent('Test Post'))
     expect(url).toContain(encodeURIComponent('https://example.com/post'))
+  })
+
+  it('copies the current URL to clipboard when copy link is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    // @ts-expect-error test shim for clipboard
+    global.navigator.clipboard = { writeText }
+
+    render(<SocialShareButtons title='Test Post' />)
+    fireEvent.click(screen.getByLabelText('Copy link'))
+
+    expect(writeText).toHaveBeenCalledWith('https://example.com/post')
+    expect(await screen.findByText('Link copied')).toBeInTheDocument()
   })
 })

--- a/src/components/SocialShareButtons.tsx
+++ b/src/components/SocialShareButtons.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Box, IconButton, Tooltip } from '@mui/material'
+import { Box, IconButton, Tooltip, Snackbar } from '@mui/material'
 import TwitterIcon from '@mui/icons-material/Twitter'
 import LinkedInIcon from '@mui/icons-material/LinkedIn'
 import FacebookIcon from '@mui/icons-material/Facebook'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 
 interface SocialShareButtonsProps {
   title: string
@@ -25,42 +26,68 @@ const getShareUrl = (platform: 'twitter' | 'linkedin' | 'facebook', title: strin
 
 const SocialShareButtons: React.FC<SocialShareButtonsProps> = ({ title }) => {
   const url = typeof window !== 'undefined' ? window.location.href : ''
+  const [snackbarOpen, setSnackbarOpen] = React.useState(false)
 
   const handleShare = (platform: 'twitter' | 'linkedin' | 'facebook') => {
     const shareUrl = getShareUrl(platform, title, url)
     window.open(shareUrl, '_blank', 'noopener,noreferrer')
   }
 
+  const handleCopy = () => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && url) {
+      navigator.clipboard.writeText(url)
+      setSnackbarOpen(true)
+    }
+  }
+
+  const handleSnackbarClose = () => {
+    setSnackbarOpen(false)
+  }
+
   return (
-    <Box display='flex' gap={1} mb={2}>
-      <Tooltip title='Share on Twitter'>
-        <IconButton
-          aria-label='Share on Twitter'
-          onClick={() => handleShare('twitter')}
-          size='small'
-        >
-          <TwitterIcon fontSize='small' />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title='Share on LinkedIn'>
-        <IconButton
-          aria-label='Share on LinkedIn'
-          onClick={() => handleShare('linkedin')}
-          size='small'
-        >
-          <LinkedInIcon fontSize='small' />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title='Share on Facebook'>
-        <IconButton
-          aria-label='Share on Facebook'
-          onClick={() => handleShare('facebook')}
-          size='small'
-        >
-          <FacebookIcon fontSize='small' />
-        </IconButton>
-      </Tooltip>
-    </Box>
+    <>
+      <Box display='flex' gap={1} mb={2}>
+        <Tooltip title='Copy link'>
+          <IconButton aria-label='Copy link' onClick={handleCopy} size='small'>
+            <ContentCopyIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title='Share on Twitter'>
+          <IconButton
+            aria-label='Share on Twitter'
+            onClick={() => handleShare('twitter')}
+            size='small'
+          >
+            <TwitterIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title='Share on LinkedIn'>
+          <IconButton
+            aria-label='Share on LinkedIn'
+            onClick={() => handleShare('linkedin')}
+            size='small'
+          >
+            <LinkedInIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title='Share on Facebook'>
+          <IconButton
+            aria-label='Share on Facebook'
+            onClick={() => handleShare('facebook')}
+            size='small'
+          >
+            <FacebookIcon fontSize='small' />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Snackbar
+        open={snackbarOpen}
+        onClose={handleSnackbarClose}
+        autoHideDuration={1500}
+        message='Link copied'
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
This PR adds a copy-link button to SocialShareButtons and a brief “Link copied” Snackbar. Tests updated.
### Changes

- Add copy button using clipboard API
- Show Snackbar confirmation
- Update tests