### PR TITLE
feat: add aria labels to external links

### DIFF
--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -54,6 +54,7 @@ const Links: React.FC<{ links: Link[] }> = ({ links }) => {
             component='a'
             fullWidth={isMobile}
             sx={isMobile ? { justifyContent: 'flex-start' } : undefined}
+            aria-label={`${link.text} (opens in new window)`}
           >
             {link.text}
           </Button>


### PR DESCRIPTION
This PR adds explicit aria-labels for external links

### Changes
- Adds `aria-label` attribute to external link buttons
- Labels include "(opens in new window)" for clarity
- Improves accessibility for screen reader users

### Impact
- Better user experience for assistive technology users
- Follows WCAG accessibility guidelines
- Maintains existing component functionality