### PR TITLE
feat: add norel to external links

### DIFF
--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -50,6 +50,7 @@ const Links: React.FC<{ links: Link[] }> = ({ links }) => {
             color='primary'
             href={link.href}
             target='_blank'
+            rel='noopener noreferrer'
             key={link.href}
             component='a'
             fullWidth={isMobile}


### PR DESCRIPTION
This PR adds security hardening to external links in the Links component.

### What Changed
- Added `rel="noopener noreferrer"` to Button components with `target="_blank"`

### Why This Matters
- Prevents external sites from accessing `window.opener` property
- Protects against potential page manipulation attacks
- Follows OWASP security best practices for external links