### PR TITLE
feat: add aria-current to active links

### DIFF
--- a/src/components/RecentPosts.test.tsx
+++ b/src/components/RecentPosts.test.tsx
@@ -18,14 +18,13 @@ vi.mock('@mui/material', async () => {
 })
 
 describe('RecentPosts', () => {
-  it('renders the post list and allows expanding/collapsing', () => {
-    // Create mock posts for testing
-    const mockPosts: Post[] = [
-      { title: 'Test Post 1', path: '/test-1' },
-      { title: 'Test Post 2', path: '/test-2' },
-      { title: 'Test Post 3', path: '/test-3' },
-    ]
+  const mockPosts: Post[] = [
+    { title: 'Test Post 1', path: '/test-1' },
+    { title: 'Test Post 2', path: '/test-2' },
+    { title: 'Test Post 3', path: '/test-3' },
+  ]
 
+  it('renders the post list and allows expanding/collapsing', () => {
     // Arrange
     render(
       <MemoryRouter>
@@ -66,5 +65,130 @@ describe('RecentPosts', () => {
 
     // Collapse container should be hidden again
     expect(collapseContainer).toHaveStyle('display: none')
+  })
+
+  describe('aria-current functionality', () => {
+    it('sets aria-current="page" on the active link when path matches current location', () => {
+      // Arrange - Render with a specific initial location
+      render(
+        <MemoryRouter initialEntries={['/test-2']}>
+          <RecentPosts posts={mockPosts} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list to see all links
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // Find the link that should be active
+      const activeLink = screen.getByRole('link', { name: 'Test Post 2' })
+      expect(activeLink).toHaveAttribute('aria-current', 'page')
+
+      // Verify other links don't have aria-current
+      const inactiveLink1 = screen.getByRole('link', { name: 'Test Post 1' })
+      const inactiveLink3 = screen.getByRole('link', { name: 'Test Post 3' })
+
+      expect(inactiveLink1).not.toHaveAttribute('aria-current')
+      expect(inactiveLink3).not.toHaveAttribute('aria-current')
+    })
+
+    it('sets aria-current="page" on home page link when at root path', () => {
+      // Arrange - Render with root path
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <RecentPosts posts={mockPosts} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // Since we're at root path, no post should be active
+      mockPosts.forEach((post) => {
+        const link = screen.getByRole('link', { name: post.title })
+        expect(link).not.toHaveAttribute('aria-current')
+      })
+    })
+
+    it('handles exact path matching correctly', () => {
+      // Arrange - Render with a path that partially matches but shouldn't be active
+      render(
+        <MemoryRouter initialEntries={['/test-1-extra']}>
+          <RecentPosts posts={mockPosts} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // No link should be active since paths don't match exactly
+      mockPosts.forEach((post) => {
+        const link = screen.getByRole('link', { name: post.title })
+        expect(link).not.toHaveAttribute('aria-current')
+      })
+    })
+
+    it('handles different locations correctly for aria-current', () => {
+      // Test that aria-current is properly applied in different location scenarios
+
+      // Test case 1: No active link when at different path
+      render(
+        <MemoryRouter initialEntries={['/different-path']}>
+          <RecentPosts posts={mockPosts} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // Verify no links are active when at different path
+      mockPosts.forEach((post) => {
+        const link = screen.getByRole('link', { name: post.title })
+        expect(link).not.toHaveAttribute('aria-current')
+      })
+    })
+
+    it('applies aria-current correctly when location matches post path', () => {
+      // Test that aria-current is properly applied when location matches
+      render(
+        <MemoryRouter initialEntries={['/test-1']}>
+          <RecentPosts posts={mockPosts} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // The first post should be active
+      const activeLink = screen.getByRole('link', { name: 'Test Post 1' })
+      expect(activeLink).toHaveAttribute('aria-current', 'page')
+
+      // Other posts should not be active
+      const inactiveLink2 = screen.getByRole('link', { name: 'Test Post 2' })
+      const inactiveLink3 = screen.getByRole('link', { name: 'Test Post 3' })
+
+      expect(inactiveLink2).not.toHaveAttribute('aria-current')
+      expect(inactiveLink3).not.toHaveAttribute('aria-current')
+    })
+
+    it('handles empty posts array gracefully', () => {
+      // Arrange - Render with no posts
+      render(
+        <MemoryRouter initialEntries={['/test-1']}>
+          <RecentPosts posts={[]} />
+        </MemoryRouter>,
+      )
+
+      // Expand the posts list
+      const expandButton = screen.getByLabelText('expand posts')
+      fireEvent.click(expandButton)
+
+      // Should not crash and should show no posts
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/components/RecentPosts.tsx
+++ b/src/components/RecentPosts.tsx
@@ -14,7 +14,7 @@ import {
   useMediaQuery,
   Theme,
 } from '@mui/material'
-import { Link as RouterLink } from 'react-router-dom'
+import { Link as RouterLink, useLocation } from 'react-router-dom'
 import ArticleIcon from '@mui/icons-material/Article'
 import ArrowRightAltIcon from '@mui/icons-material/ArrowRightAlt'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -43,12 +43,16 @@ interface PostItemProps {
 }
 
 const PostItem = memo(({ post, index, theme }: PostItemProps) => {
+  const location = useLocation()
+  const isActive = location.pathname === post.path
+
   return (
     <React.Fragment>
       {index > 0 && <Divider component='li' variant='inset' />}
       <ListItem
         component={RouterLink}
         to={post.path}
+        aria-current={isActive ? 'page' : undefined}
         sx={{
           py: 1.5,
           px: 2,


### PR DESCRIPTION
## This PR adds aria-current to active navigation links

### What
- Implements `aria-current="page"` on active links in RecentPosts component
- Uses `useLocation` to detect current route and compare with post paths
- Maintains existing functionality and styling

### Why
- Improves accessibility for screen readers
- Helps users identify current page in navigation
- Follows WAI-ARIA guidelines for navigation landmarks