### PR TITLE
feat: add social meta tags to 404 page

### DIFF
--- a/src/pages/NotFound.test.tsx
+++ b/src/pages/NotFound.test.tsx
@@ -47,21 +47,30 @@ describe('NotFound', () => {
   it('sets the correct page metadata', () => {
     renderComponent()
 
-    // With our simple mock, we're just testing that the Helmet component is rendered
+    // With our simple mock, we're just testing that Helmet components are rendered
     // with the appropriate children, not the actual Helmet functionality
-    const helmet = screen.getByTestId('helmet')
+    const helmets = screen.getAllByTestId('helmet')
+    expect(helmets).toHaveLength(2)
 
-    // Verify the title is set
-    const title = Array.from(helmet.children).find(
+    // First helmet should contain title and robots meta tag
+    const firstHelmet = helmets[0]
+    const title = Array.from(firstHelmet.children).find(
       (child) => (child as HTMLElement).tagName.toLowerCase() === 'title',
     )
     expect(title).toHaveTextContent('404 - Page Not Found')
 
     // Verify the meta tag for robots is present
-    const metaTags = Array.from(helmet.children).filter(
+    const metaTags = Array.from(firstHelmet.children).filter(
       (child) => (child as HTMLElement).tagName.toLowerCase() === 'meta',
     )
     expect(metaTags.length).toBeGreaterThan(0)
+
+    // Second helmet should contain social meta tags
+    const secondHelmet = helmets[1]
+    const socialMetaTags = Array.from(secondHelmet.children).filter(
+      (child) => (child as HTMLElement).tagName.toLowerCase() === 'meta',
+    )
+    expect(socialMetaTags.length).toBeGreaterThan(0)
   })
 
   /**

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box, Typography, Button } from '@mui/material'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
+import SocialMeta from '../components/SocialMeta'
 
 const NotFound: React.FC = () => {
   return (
@@ -17,6 +18,11 @@ const NotFound: React.FC = () => {
         <title>404 - Page Not Found</title>
         <meta name='robots' content='noindex, nofollow' />
       </Helmet>
+      <SocialMeta
+        title='404 - Page Not Found'
+        description="The page you're looking for doesn't exist. Please check the URL or return to the home page."
+        type='website'
+      />
       <Typography variant='h1' component='h2' gutterBottom>
         404
       </Typography>


### PR DESCRIPTION
This PR adds social meta tags to the 404 page using the new SocialMeta component.

## Changes
- Import SocialMeta component in NotFound.tsx
- Add comprehensive Open Graph and Twitter Card meta tags
- Maintain existing title and robots meta tag
- Update tests to handle dual Helmet structure