### PR TITLE
feat: replace home page with centralized social meta

### DIFF
--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -72,12 +72,12 @@ describe('Home Component', () => {
   it('includes structured data for SEO', () => {
     renderWithProvider(<Home />)
 
-    // Check for Helmet component that contains schema.org data
-    const helmet = screen.getByTestId('helmet-mock')
-    expect(helmet).toBeInTheDocument()
+    // Check for Helmet components that contain schema.org data and social meta tags
+    const helmets = screen.getAllByTestId('helmet-mock')
+    expect(helmets.length).toBe(2) // One for structured data, one for social meta tags
 
-    // Check for meta tags
-    const metaTags = screen.getAllByTestId('helmet-mock')
-    expect(metaTags.length).toBeGreaterThan(0)
+    // Check that we have the expected meta tag containers
+    expect(helmets[0]).toBeInTheDocument()
+    expect(helmets[1]).toBeInTheDocument()
   })
 })

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { helmetJsonLdProp } from 'react-schemaorg'
 import { Person } from 'schema-dts'
-import profileImage from '../assets/raymond-perez.jpg'
 import { Box } from '@mui/material'
 import Summary from '../components/Summary.tsx'
 import Links from '../components/Links.tsx'
@@ -10,6 +9,7 @@ import Education from '../components/Education.tsx'
 import Skills from '../components/Skills.tsx'
 import Achievements from '../components/Achievements.tsx'
 import { Helmet } from 'react-helmet'
+import SocialMeta from '../components/SocialMeta.tsx'
 import { PROFILE } from '../constants/profile'
 import { SKILLS } from '../constants/skills'
 
@@ -134,7 +134,7 @@ const Home: React.FC = () => {
               '@type': 'CollegeOrUniversity',
               name: 'Red Rocks Community College',
             },
-            image: profileImage,
+            image: PROFILE.image,
             url: 'https://www.rayperez.com',
             knowsAbout: [
               'Software Engineering',
@@ -165,8 +165,14 @@ const Home: React.FC = () => {
         ]}
       >
         <link rel='canonical' href='https://www.rayperez.com' />
-        <meta property='og:image' content={profileImage} />
       </Helmet>
+      <SocialMeta
+        title={PROFILE.name}
+        description='Software Engineer specializing in modern web development, performance optimization, and scalable architecture.'
+        image={PROFILE.image}
+        url='https://www.rayperez.com'
+        type='profile'
+      />
       <Box>
         <Summary />
         <Links links={links} />


### PR DESCRIPTION
## PR Description

This PR replaces the Home page's inline social meta tags with the centralized SocialMeta component.

### Changes
- Remove duplicate profile image import
- Replace single og:image tag with comprehensive social meta coverage
- Update tests to handle multiple Helmet components
- Maintain existing structured data and canonical link functionality

### Benefits
- Consistent social media appearance across platforms
- Centralized social media configuration
- Reduced code duplication
- Better SEO and social sharing optimization