### PR TITLE
feat: add social meta component to blog posts

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -12,9 +12,9 @@ import withCanonical from './WithCanonical'
 import { PROFILE } from '../constants/profile'
 import { useBookmarks } from '../hooks/useBookmarks'
 import { calculateReadingTime, formatReadingTime } from '../utils/readingTime'
-import profileImage from '../assets/raymond-perez.jpg'
 import SocialShareButtons from './SocialShareButtons'
 import { posts } from '../constants/posts'
+import SocialMeta from './SocialMeta'
 
 const AuthorBio = lazy(() => import('./AuthorBio'))
 const TableOfContents = lazy(() => import('./TableOfContents'))
@@ -91,15 +91,20 @@ const BlogPost: React.FC<BlogPostProps> = ({ title, author, date, children }) =>
               name: author,
             },
             datePublished: date,
-            image: profileImage,
+            image: PROFILE.image,
           }),
         ]}
       >
-        <meta property='og:image' content={profileImage} />
         <title>
           {title} - {PROFILE.name} - {PROFILE.role}
         </title>
       </Helmet>
+      <SocialMeta
+        title={title}
+        description={`${title} by ${author} - ${readingTimeDisplay} read`}
+        type='article'
+        url={window.location.href}
+      />
       <Box mb={2}>
         <Breadcrumbs aria-label='breadcrumb'>
           <Link component={RouterLink} color='inherit' to='/'>


### PR DESCRIPTION
This PR replaces BlogPost inline meta tags with the centralized SocialMeta component.

### Changes
- Remove duplicate profile image import
- Replace inline og:image meta tag with SocialMeta component
- Add comprehensive Open Graph and Twitter Card meta tags
- Maintain all existing functionality and tests

### Benefits
- Centralized social media configuration
- Eliminated code duplication
- Improved maintainability
- Enhanced social sharing coverage