### PR TITLE
feat: add social meta to author bio

### DIFF
--- a/src/components/AuthorBio.test.tsx
+++ b/src/components/AuthorBio.test.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@mui/material/styles'
 import { createTheme } from '@mui/material'
 import AuthorBio from './AuthorBio'
 import { PROFILE } from '../constants/profile'
+import profileImage from '../assets/raymond-perez.jpg'
 
 // Mock the Helmet component
 vi.mock('react-helmet', () => ({
@@ -119,11 +120,29 @@ describe('AuthorBio Component', () => {
     expect(headingTexts).toContain('Find me online:')
   })
 
-  it('renders Helmet component for SEO', () => {
+  it('renders social meta tags for SEO', () => {
     renderComponent()
 
-    const helmet = screen.getByTestId('helmet')
-    expect(helmet).toBeInTheDocument()
+    // Check for Open Graph meta tags
+    expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      `${PROFILE.name} - ${PROFILE.role}`,
+    )
+    expect(document.querySelector('meta[property="og:type"]')).toHaveAttribute('content', 'profile')
+    expect(document.querySelector('meta[property="og:image"]')).toHaveAttribute(
+      'content',
+      profileImage,
+    )
+
+    // Check for Twitter Card meta tags
+    expect(document.querySelector('meta[property="twitter:card"]')).toHaveAttribute(
+      'content',
+      'summary_large_image',
+    )
+    expect(document.querySelector('meta[property="twitter:creator"]')).toHaveAttribute(
+      'content',
+      PROFILE.twitterCreator,
+    )
   })
 
   it('has responsive design elements', () => {

--- a/src/components/AuthorBio.tsx
+++ b/src/components/AuthorBio.tsx
@@ -7,6 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub'
 import TwitterIcon from '@mui/icons-material/Twitter'
 import { Helmet } from 'react-helmet'
 import LazyImage from './LazyImage'
+import SocialMeta from './SocialMeta'
 import { PROFILE } from '../constants/profile'
 import profileImage from '../assets/raymond-perez.jpg'
 import { SKILLS } from '../constants/skills'
@@ -35,6 +36,13 @@ const AuthorBio: React.FC = () => {
 
   return (
     <React.Fragment>
+      <SocialMeta
+        title={`${PROFILE.name} - ${PROFILE.role}`}
+        description={`${PROFILE.name} is a ${PROFILE.role} in Denver, specializing in modern web development, performance optimization, and scalable architecture.`}
+        image={profileImage}
+        url='https://www.rayperez.com'
+        type='profile'
+      />
       <Helmet
         script={[
           helmetJsonLdProp<Person>({


### PR DESCRIPTION
This PR adds social media meta tags to the AuthorBio component using the centralized SocialMeta component.

### What Changed
- Added SocialMeta component to AuthorBio
- Configured profile-specific meta tags (title, description, image, type)
- Updated tests to verify meta tag generation

### Why
- AuthorBio previously lacked social media optimization
- Social shares showed incomplete previews
- Centralized approach improves maintainability