### PR TITLE
feat: create article content renderer component

### DIFF
--- a/src/components/ArticleRenderer.test.tsx
+++ b/src/components/ArticleRenderer.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ArticleRenderer from './ArticleRenderer'
+import { ArticleContent } from '../types/articleContent'
+
+// Mock LazySyntaxHighlighter to avoid complex dependencies
+vi.mock('./LazySyntaxHighlighter', () => ({
+  default: ({ children, language }: { children: string; language: string }) => (
+    <div data-testid='syntax-highlighter' data-language={language}>
+      {children}
+    </div>
+  ),
+}))
+
+describe('ArticleRenderer', () => {
+  it('renders heading content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'heading',
+        variant: 'h3',
+        content: 'Test Heading',
+        gutterBottom: true,
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    expect(screen.getByText('Test Heading')).toBeInTheDocument()
+    expect(screen.getByText('Test Heading').tagName).toBe('H3')
+  })
+
+  it('renders paragraph content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'paragraph',
+        variant: 'body1',
+        content: 'Test paragraph content',
+        paragraph: true,
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    expect(screen.getByText('Test paragraph content')).toBeInTheDocument()
+  })
+
+  it('renders list content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'list',
+        items: ['Item 1', 'Item 2', 'Item 3'],
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Item 2')).toBeInTheDocument()
+    expect(screen.getByText('Item 3')).toBeInTheDocument()
+  })
+
+  it('renders code content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'code',
+        language: 'javascript',
+        code: 'console.log("Hello World")',
+        elevation: 3,
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    const syntaxHighlighter = screen.getByTestId('syntax-highlighter')
+    expect(syntaxHighlighter).toBeInTheDocument()
+    expect(syntaxHighlighter).toHaveAttribute('data-language', 'javascript')
+    expect(syntaxHighlighter).toHaveTextContent('console.log("Hello World")')
+  })
+
+  it('renders divider content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'divider',
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    // Material-UI Divider renders as an hr element
+    expect(document.querySelector('hr')).toBeInTheDocument()
+  })
+
+  it('renders link content correctly', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'link',
+        title: 'Test Link',
+        href: 'https://example.com',
+        target: '_blank',
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    const link = screen.getByText('Test Link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders multiple content items in sequence', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'heading',
+        variant: 'h3',
+        content: 'Section Title',
+      },
+      {
+        type: 'paragraph',
+        content: 'Section description',
+      },
+      {
+        type: 'list',
+        items: ['Point 1', 'Point 2'],
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    expect(screen.getByText('Section Title')).toBeInTheDocument()
+    expect(screen.getByText('Section description')).toBeInTheDocument()
+    expect(screen.getByText('Point 1')).toBeInTheDocument()
+    expect(screen.getByText('Point 2')).toBeInTheDocument()
+  })
+
+  it('handles empty content array', () => {
+    const content: ArticleContent[] = []
+
+    render(<ArticleRenderer content={content} />)
+
+    // Should render without errors
+    expect(document.body).toBeInTheDocument()
+  })
+
+  it('handles unknown content type gracefully', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'unknown' as never,
+        content: 'This should not render',
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    expect(screen.queryByText('This should not render')).not.toBeInTheDocument()
+  })
+
+  it('uses default values when optional properties are missing', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'heading',
+        content: 'Default Heading',
+      },
+      {
+        type: 'paragraph',
+        content: 'Default paragraph',
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    const heading = screen.getByText('Default Heading')
+    const paragraph = screen.getByText('Default paragraph')
+
+    expect(heading.tagName).toBe('H3') // Default variant
+    expect(paragraph).toBeInTheDocument()
+  })
+
+  it('renders code block with custom styling', () => {
+    const content: ArticleContent[] = [
+      {
+        type: 'code',
+        language: 'typescript',
+        code: 'const test = "value"',
+        elevation: 5,
+        style: { marginTop: '20px' },
+      },
+    ]
+
+    render(<ArticleRenderer content={content} />)
+
+    const syntaxHighlighter = screen.getByTestId('syntax-highlighter')
+    expect(syntaxHighlighter).toBeInTheDocument()
+    expect(syntaxHighlighter).toHaveAttribute('data-language', 'typescript')
+  })
+})

--- a/src/components/ArticleRenderer.tsx
+++ b/src/components/ArticleRenderer.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { Typography, List, ListItem, ListItemText, Paper, Link, Divider } from '@mui/material'
+import LazySyntaxHighlighter from './LazySyntaxHighlighter'
+import { ArticleContent } from '../types/articleContent'
+
+interface ArticleRendererProps {
+  content: ArticleContent[]
+}
+
+const ArticleRenderer: React.FC<ArticleRendererProps> = ({ content }) => {
+  const renderHeading = (item: ArticleContent): React.ReactElement => (
+    <Typography
+      key={`${item.type}-${item.content}`}
+      variant={item.variant || 'h3'}
+      component={
+        item.variant?.startsWith('h')
+          ? (item.variant as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')
+          : 'h3'
+      }
+      gutterBottom={item.gutterBottom}
+    >
+      {item.content}
+    </Typography>
+  )
+
+  const renderParagraph = (item: ArticleContent): React.ReactElement => (
+    <Typography
+      key={`${item.type}-${item.content}`}
+      variant={item.variant || 'body1'}
+      paragraph={item.paragraph}
+    >
+      {item.content}
+    </Typography>
+  )
+
+  const renderList = (item: ArticleContent): React.ReactElement => (
+    <List key={`${item.type}-${item.items?.join('-')}`}>
+      {item.items?.map((listItem, index) => (
+        <ListItem key={index}>
+          <ListItemText primary={listItem} />
+        </ListItem>
+      ))}
+    </List>
+  )
+
+  const renderCode = (item: ArticleContent): React.ReactElement => (
+    <Paper
+      key={`${item.type}-${item.language}`}
+      elevation={item.elevation || 3}
+      style={{ marginBottom: '16px', ...item.style }}
+    >
+      <LazySyntaxHighlighter language={item.language || 'text'}>
+        {item.code || ''}
+      </LazySyntaxHighlighter>
+    </Paper>
+  )
+
+  const renderDivider = (item: ArticleContent): React.ReactElement => (
+    <Divider key={`${item.type}-${Date.now()}`} sx={{ my: 2 }} />
+  )
+
+  const renderLink = (item: ArticleContent): React.ReactElement => (
+    <Link
+      key={`${item.type}-${item.href}`}
+      href={item.href}
+      target={item.target || '_blank'}
+      rel={item.target === '_blank' ? 'noopener noreferrer' : undefined}
+      color='primary'
+      underline='hover'
+    >
+      {item.title || item.content}
+    </Link>
+  )
+
+  const renderContent = (item: ArticleContent): React.ReactElement | null => {
+    switch (item.type) {
+      case 'heading':
+        return renderHeading(item)
+      case 'paragraph':
+        return renderParagraph(item)
+      case 'list':
+        return renderList(item)
+      case 'code':
+        return renderCode(item)
+      case 'divider':
+        return renderDivider(item)
+      case 'link':
+        return renderLink(item)
+      default:
+        return null
+    }
+  }
+
+  return <>{content.map(renderContent)}</>
+}
+
+export default ArticleRenderer

--- a/src/types/articleContent.ts
+++ b/src/types/articleContent.ts
@@ -1,0 +1,15 @@
+export interface ArticleContent {
+  type: 'heading' | 'paragraph' | 'list' | 'code' | 'divider' | 'link'
+  variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body1' | 'body2' | 'caption'
+  content?: string
+  items?: string[]
+  language?: string
+  code?: string
+  title?: string
+  href?: string
+  target?: '_blank' | '_self' | '_parent' | '_top'
+  gutterBottom?: boolean
+  paragraph?: boolean
+  elevation?: number
+  style?: Record<string, string>
+}


### PR DESCRIPTION
This PR implements the foundation infrastructure for JSON-driven article content.

## What
- Creates TypeScript interface for ArticleContent schema
- Builds generic ArticleRenderer component with all content type handlers
- Adds comprehensive tests for ArticleRenderer component

## Impact
Enables future refactoring of articles to use structured JSON content while maintaining existing functionality and appearance.