### PR TITLE
feat: add seo schema improvements

### DIFF
--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -3,4 +3,12 @@ export const PROFILE = {
   role: 'Software Engineer',
   image: '/assets/raymond-perez.jpg',
   twitterCreator: '@onlyray7',
+  email: 'ray@rayperez.com',
+  location: {
+    city: 'Denver',
+    state: 'CO',
+    country: 'US',
+  },
+  description:
+    'Senior Software Engineer specializing in modern web development, performance optimization, and scalable architecture. Experienced in React.js, Node.js, TypeScript, and Laravel.',
 } as const

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -125,7 +125,15 @@ const Home: React.FC = () => {
             '@context': 'https://schema.org',
             '@type': 'Person',
             name: PROFILE.name,
+            description: PROFILE.description,
             jobTitle: PROFILE.role,
+            email: PROFILE.email,
+            address: {
+              '@type': 'PostalAddress',
+              addressLocality: PROFILE.location.city,
+              addressRegion: PROFILE.location.state,
+              addressCountry: PROFILE.location.country,
+            },
             worksFor: {
               '@type': 'Organization',
               name: 'Red Ventures',


### PR DESCRIPTION
This PR adds critical Person schema.org properties to the home page to improve SEO and rich snippet potential.

### Changes Made

**Profile Constants (`src/constants/profile.ts`)**
- Added `email` property for contact information
- Added `location` object with city, state, and country
- Added `description` with professional bio

**Person Schema (`src/pages/Home.tsx`)**
- Added `description` property for search engine context
- Added `email` property for professional contact
- Added `address` property using PostalAddress schema
- Removed unused image URL construction logic