### PR TITLE
fix: remove redundant links

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -114,8 +114,6 @@ const achievements = [
 const links = [
   { text: 'Prejump', href: 'https://prejump.com' },
   { text: 'Twitch', href: 'https://twitch.tv/onlyray' },
-  { text: 'GitHub', href: 'https://github.com/rspraymond' },
-  { text: 'LinkedIn', href: 'https://www.linkedin.com/in/raymond-perez-eng/' },
   { text: 'Twitter', href: 'https://twitter.com/onlyray7' },
   { text: 'Twitch Clips Finder', href: 'http://clipsfinder.com' },
   { text: 'Palworld Fast Travel Map', href: 'https://palworld-map.appsample.com' },


### PR DESCRIPTION
This PR removes duplicate GitHub and LinkedIn links from the Home page Links section to eliminate redundancy while maintaining accessibility.

### Changes
- Removed GitHub and LinkedIn entries from `links` array in `Home.tsx`
- Preserved 5 unique external links (Prejump, Twitch, Twitter, Twitch Clips Finder, Palworld Fast Travel Map)