### PR TITLE
fix: upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5869,9 +5869,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
This PR updates the npm lockfile so **lodash** resolves to **4.18.1** instead of **4.17.23**. **Lodash** is not a direct dependency; it is pulled in by **`@testing-library/jest-dom`** (dev, used when running tests). The public site content is unchanged.

## Why this version

**Lodash 4.18.0** (you effectively take **4.18.1**) includes security fixes the maintainers published in their release notes:

- **`_.unset` / `_.omit`**: prototype pollution via `constructor` / `prototype` path handling. Advisory: [GHSA-f23m-r3pf-42rh](https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh).
- **`_.template`**: code injection risk through `imports` keys (follow on to older template related issues). Advisories: [GHSA-r5fr-rjxr-66jc](https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc), **CVE-2026-4800**.

**4.18.1** addresses a **ReferenceError** in some published lodash bundles affecting **`template`** and **`fromPairs`** in modular builds ([release notes](https://github.com/lodash/lodash/releases/tag/4.18.1)).